### PR TITLE
Release 3.1.1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ on:
 
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:
@@ -24,11 +24,14 @@ jobs:
           java-version: 25
       - name: Build with Gradle
         run: ./gradlew clean build
+      - name: Resolve shadow artifact version
+        id: build-version
+        run: echo "version=$(./gradlew -q printVersion)" >> "$GITHUB_OUTPUT"
       - name: Upload artifact
         uses: actions/upload-artifact@v4.4.3
         with:
           name: CommandPrompter
-          path: prompt-paper/build/libs
+          path: prompt-paper/build/libs/CommandPrompterPaper-${{ steps.build-version.outputs.version }}.jar
 
   publish:
     if: github.event_name == 'release'
@@ -42,25 +45,34 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
-      - name: Publish to Kakuno
+      - name: Verify release version
+        id: verify-release
         env:
-          KAKUNO_USER: ${{ secrets.KAKUNO_USER }}
-          KAKUNO_TOKEN: ${{ secrets.KAKUNO_TOKEN }}
-        run: ./gradlew clean build publish
-
-      - name: Export LATEST_TAG
+          GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "LATEST_TAG=$(curl -qsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/releases/latest" \
-          | jq -r .tag_name)" >> $GITHUB_ENV
+          set -eu
+          project_version="$(./gradlew -q printVersion)"
+          release_version="${GITHUB_RELEASE_TAG#v}"
+          ./gradlew :prompt-paper:processResources
+          plugin_version="$(
+            awk -F": *" '/^version:/ { gsub(/[\047\042]/, "", $2); print $2; exit }' \
+              prompt-paper/build/resources/main/paper-plugin.yml
+          )"
+          test "$release_version" = "$project_version" \
+            || { echo "Release tag $GITHUB_RELEASE_TAG does not match Gradle version $project_version" >&2; exit 1; }
+          test "$release_version" = "$plugin_version" \
+            || { echo "Release tag $GITHUB_RELEASE_TAG does not match plugin version $plugin_version" >&2; exit 1; }
+          echo "version=$release_version" >> "$GITHUB_OUTPUT"
+
+      - name: Build shadow jar
+        run: ./gradlew clean build
+
       - name: Upload Release Artifact
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run:
-          gh release upload ${{ env.LATEST_TAG }} prompt-paper/build/libs/*.jar
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "prompt-paper/build/libs/CommandPrompterPaper-${{ steps.verify-release.outputs.version }}.jar"
 
       - name: Publish to Modrinth
         uses: Kir-Antipov/mc-publish@v3.3
@@ -75,11 +87,9 @@ jobs:
 
           loaders: |
             paper
-            spigot
             purpur
           game-versions: |
-            1.21.4
+            26.1.2
+            26.2
 
-          files: prompt-paper/build/libs/CommandPrompterPaper-*.jar
-
-
+          files: prompt-paper/build/libs/CommandPrompterPaper-${{ steps.verify-release.outputs.version }}.jar

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cache/
 # Codacy
 .codacy/
 .codacy.yaml
+
+# Local deep-work progress state
+.slim/deepwork/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 allprojects {
     group = "dev.cyr1en"
-    version = "3.1.0"
+    version = "3.1.1"
 }
 
 tasks.register("printVersion") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,11 @@ allprojects {
     version = "3.1.0"
 }
 
+tasks.register("printVersion") {
+    description = "Print the Gradle project version for release checks."
+    doLast { println(project.version) }
+}
+
 subprojects {
     apply(plugin = "maven-publish")
 

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/ParsedCommand.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/ParsedCommand.java
@@ -3,33 +3,69 @@ package dev.cyr1en.promptcore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
  * The result of parsing a raw command string.
  *
- * <p>Contains the original command template alongside the extracted prompt tags and post-command
- * metas. The {@link #templateCommand} preserves the original string so that prompt tag bodies can
- * be replaced with answers at assembly time.
- *
- * @param templateCommand the original command string (unchanged)
- * @param promptTags ordered list of prompt tags extracted from the command
- * @param postCmds list of post-command metas extracted from the command
- * @param parserConfig the config used to parse this command
+ * <p>{@link #templateCommand()} retains the historical unescaped view used by callers. The raw
+ * command and the exact spans of parsed tags are retained separately so assembly can replace tags
+ * in the original source, rather than searching through already-replaced answer text.
  */
 public record ParsedCommand(
     String templateCommand,
     List<PromptTag> promptTags,
     List<PostCommandMeta> postCmds,
-    ParserConfig parserConfig) {
+    ParserConfig parserConfig,
+    String rawTemplateCommand,
+    List<TemplateSpan> templateSpans) {
 
-  /** Compact constructor that validates non-null components. */
+  /**
+   * Describes one tag that was actually parsed. Filtered tags, escaped tags, and ordinary literals
+   * deliberately have no span and therefore remain untouched during assembly.
+   *
+   * @param start start offset in {@link ParsedCommand#rawTemplateCommand()}
+   * @param end exclusive end offset in the raw command
+   * @param rawText the exact source text covered by this span
+   * @param pcm whether the span is a parsed post-command meta
+   * @param parsedIndex index in {@link #postCmds()} or {@link #promptTags()}, according to {@code
+   *     pcm}
+   */
+  public record TemplateSpan(int start, int end, String rawText, boolean pcm, int parsedIndex) {
+    public TemplateSpan {
+      Objects.requireNonNull(rawText, "rawText");
+      if (start < 0 || end < start || end - start != rawText.length()) {
+        throw new IllegalArgumentException("Invalid parsed template span: " + start + ".." + end);
+      }
+      if (parsedIndex < 0) throw new IllegalArgumentException("parsedIndex must not be negative");
+    }
+  }
+
+  /**
+   * Backward-compatible constructor for callers that construct a parsed command directly. Commands
+   * produced by {@link dev.cyr1en.promptcore.parser.CommandLineParser} use the raw-span
+   * constructor.
+   */
+  public ParsedCommand(
+      String templateCommand,
+      List<PromptTag> promptTags,
+      List<PostCommandMeta> postCmds,
+      ParserConfig parserConfig) {
+    this(templateCommand, promptTags, postCmds, parserConfig, templateCommand, List.of());
+  }
+
+  /** Compact constructor that defensively copies all live collections. */
   public ParsedCommand {
     Objects.requireNonNull(templateCommand);
     Objects.requireNonNull(promptTags);
     Objects.requireNonNull(postCmds);
     Objects.requireNonNull(parserConfig);
+    Objects.requireNonNull(rawTemplateCommand);
+    Objects.requireNonNull(templateSpans);
+    promptTags = List.copyOf(promptTags);
+    postCmds = List.copyOf(postCmds);
+    templateSpans = List.copyOf(templateSpans);
+    validateSpans(rawTemplateCommand, templateSpans, promptTags.size(), postCmds.size());
   }
 
   /** Number of prompt tags in this command. */
@@ -47,6 +83,24 @@ public record ParsedCommand(
     return !promptTags.isEmpty();
   }
 
+  /** Defensive accessor for the parsed prompt list. */
+  @Override
+  public List<PromptTag> promptTags() {
+    return List.copyOf(promptTags);
+  }
+
+  /** Defensive accessor for the parsed PCM list. */
+  @Override
+  public List<PostCommandMeta> postCmds() {
+    return List.copyOf(postCmds);
+  }
+
+  /** Defensive accessor for source spans. */
+  @Override
+  public List<TemplateSpan> templateSpans() {
+    return List.copyOf(templateSpans);
+  }
+
   /** PCMs that run on successful completion ({@code <!...>}). */
   public List<PostCommandMeta> onCompletePCMs() {
     return postCmds.stream().filter(pcm -> !pcm.onCancel()).toList();
@@ -60,75 +114,132 @@ public record ParsedCommand(
   /**
    * Build a "partial command" string suitable for Brigadier parsing at the current prompt position.
    *
-   * <p>The first {@code answers.size()} prompt tags are replaced by their answers. For the first
-   * <b>unanswered single tag</b> (and any tokens after it in the template), the command is
-   * <b>truncated at the tag's position</b> so the cursor sits at the empty argument slot. This is
-   * what Brigadier needs to produce completions for the current argument only — tokens after the
-   * current tag have not been "typed" yet from the user's perspective and would otherwise push the
-   * cursor to a position with no completions.
-   *
-   * <p>Compound tags (e.g. {@code <d:choice:set && d:num[0,24]:Value>}) keep the legacy replacement
-   * behavior: the whole compound is replaced with sub-answers joined by spaces, with empty
-   * sub-answers at the end producing a trailing space. {@code d:tab} is rejected in compound tags
-   * by the parser, so this branch is unreachable for tab completion and the legacy behavior is
-   * preserved.
-   *
-   * <p>When all tags are answered (e.g. {@link
-   * dev.cyr1en.promptcore.session.PromptSession#finish}), the loop processes every tag and the
-   * truncation branch is never reached — the result is the fully-assembled command.
-   *
-   * <p>Unanswered tags are removed (not left as raw markup) so Brigadier does not see {@code
-   * <d:...>} tokens it cannot parse. Post-command metas ({@code <! ...>} / {@code <!! ...>}) are
-   * stripped from the result — they are not part of the user's typed command path.
-   *
-   * <p>The result is trimmed and suffixed with a single trailing space so the cursor sits at the
-   * start of the next argument (the completion point).
+   * <p>The assembly walks the original raw template once. It never searches the command after an
+   * answer has been inserted, so duplicate tags remain distinct and answer text containing markup
+   * cannot be interpreted as another tag. Unescaping is performed only after all replacements.
    */
   public static String buildPartialCommand(ParsedCommand parsed, List<String> answers) {
     Objects.requireNonNull(parsed);
     Objects.requireNonNull(answers);
-    var template = parsed.templateCommand();
-    var answerIdx = 0;
-    var command = template;
-    for (var tag : parsed.promptTags()) {
-      if (answerIdx >= answers.size() && !tag.isCompound()) {
-        int idx = command.indexOf(tag.rawTag());
-        if (idx >= 0) {
-          command = command.substring(0, idx);
-        }
+
+    var rawTemplate = parsed.rawTemplateCommand();
+    var spans = parsed.templateSpans();
+    if (spans.isEmpty() && (!parsed.promptTags.isEmpty() || !parsed.postCmds.isEmpty())) {
+      return buildLegacyPartialCommand(parsed, answers);
+    }
+
+    var command = new StringBuilder(rawTemplate.length());
+    var cursor = 0;
+    var answerIndex = 0;
+    var stoppedAtUnanswered = false;
+    for (var span : spans) {
+      command.append(rawTemplate, cursor, span.start());
+      if (span.pcm()) {
+        cursor = span.end();
+        continue;
+      }
+
+      var tag = parsed.promptTags.get(span.parsedIndex());
+      if (answerIndex >= answers.size() && !tag.isCompound()) {
+        // The current tag and everything after it are not part of the command Brigadier should
+        // parse. The literal prefix has already been appended.
+        stoppedAtUnanswered = true;
         break;
       }
+
       if (tag.isCompound()) {
         var parts = new ArrayList<String>(tag.subTags().size());
         for (int i = 0; i < tag.subTags().size(); i++) {
-          parts.add(answerIdx < answers.size() ? answers.get(answerIdx) : "");
-          answerIdx++;
+          parts.add(answerIndex < answers.size() ? answers.get(answerIndex) : "");
+          answerIndex++;
         }
-        var joined = parts.stream().filter(p -> !p.isEmpty()).collect(Collectors.joining(" "));
-        int idx = command.indexOf(tag.rawTag());
-        if (idx >= 0) {
-          command =
-              command.substring(0, idx) + joined + command.substring(idx + tag.rawTag().length());
-        }
+        command.append(parts.stream().filter(p -> !p.isEmpty()).collect(Collectors.joining(" ")));
       } else {
-        String replacement = answerIdx < answers.size() ? answers.get(answerIdx) : "";
-        int idx = command.indexOf(tag.rawTag());
-        if (idx >= 0) {
-          command =
-              command.substring(0, idx)
-                  + replacement
-                  + command.substring(idx + tag.rawTag().length());
-        }
-        answerIdx++;
+        command.append(answers.get(answerIndex++));
       }
+      cursor = span.end();
     }
-    var config = parsed.parserConfig();
-    for (var pcm : parsed.postCmds()) {
-      command =
-          command.replaceAll(
-              Pattern.quote(config.opening()) + "!.*?" + Pattern.quote(config.closing()), "");
-    }
-    var trimmed = command.trim();
+
+    // If a single prompt was unanswered, the loop intentionally stopped before advancing the
+    // cursor. Otherwise all ordinary literals after the final parsed span are retained.
+    if (!stoppedAtUnanswered) command.append(rawTemplate, cursor, rawTemplate.length());
+
+    var unescaped = unescape(command.toString(), parsed.parserConfig());
+    var trimmed = unescaped.trim();
     return trimmed.endsWith(" ") ? trimmed : trimmed + " ";
+  }
+
+  /**
+   * Fallback for the old four-argument constructor. New parser output always carries spans; this
+   * path keeps source compatibility for integrations that build ParsedCommand values themselves.
+   */
+  private static String buildLegacyPartialCommand(ParsedCommand parsed, List<String> answers) {
+    var template = parsed.templateCommand;
+    var answerIndex = 0;
+    var cursor = 0;
+    var command = new StringBuilder(template.length());
+    for (var tag : parsed.promptTags) {
+      var index = template.indexOf(tag.rawTag(), cursor);
+      if (index < 0) break;
+      command.append(template, cursor, index);
+      if (answerIndex >= answers.size() && !tag.isCompound()) break;
+      if (tag.isCompound()) {
+        var parts = new ArrayList<String>(tag.subTags().size());
+        for (int i = 0; i < tag.subTags().size(); i++) {
+          parts.add(answerIndex < answers.size() ? answers.get(answerIndex) : "");
+          answerIndex++;
+        }
+        command.append(parts.stream().filter(p -> !p.isEmpty()).collect(Collectors.joining(" ")));
+      } else {
+        command.append(answers.get(answerIndex++));
+      }
+      cursor = index + tag.rawTag().length();
+    }
+    if (cursor == 0 || answerIndex >= parsed.promptTags.size()) {
+      command.append(template.substring(cursor));
+    }
+    // Do not use a wildcard PCM expression here: only spans from the parser are authoritative.
+    var trimmed = command.toString().trim();
+    return trimmed.endsWith(" ") ? trimmed : trimmed + " ";
+  }
+
+  private static String unescape(String input, ParserConfig config) {
+    if (input == null || input.isEmpty()) return input;
+    char escape = config.escape().charAt(0);
+    char opening = config.opening().charAt(0);
+    char closing = config.closing().charAt(0);
+    var result = new StringBuilder(input.length());
+    for (int i = 0; i < input.length(); i++) {
+      char current = input.charAt(i);
+      if (current == escape && i + 1 < input.length()) {
+        char next = input.charAt(i + 1);
+        if (next == opening || next == closing) {
+          result.append(next);
+          i++;
+          continue;
+        }
+      }
+      result.append(current);
+    }
+    return result.toString();
+  }
+
+  private static void validateSpans(
+      String rawTemplate, List<TemplateSpan> spans, int promptCount, int pcmCount) {
+    var previousEnd = 0;
+    for (var span : spans) {
+      if (span.start() < previousEnd || span.end() > rawTemplate.length()) {
+        throw new IllegalArgumentException(
+            "Parsed template spans must be ordered and non-overlapping");
+      }
+      if (!rawTemplate.regionMatches(span.start(), span.rawText(), 0, span.rawText().length())) {
+        throw new IllegalArgumentException("Parsed template span does not match the raw template");
+      }
+      int count = span.pcm() ? pcmCount : promptCount;
+      if (span.parsedIndex() >= count) {
+        throw new IllegalArgumentException("Parsed template span has an invalid parsed index");
+      }
+      previousEnd = span.end();
+    }
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/ParsedCommand.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/ParsedCommand.java
@@ -105,10 +105,20 @@ public record ParsedCommand(
           answerIdx++;
         }
         var joined = parts.stream().filter(p -> !p.isEmpty()).collect(Collectors.joining(" "));
-        command = command.replace(tag.rawTag(), joined);
+        int idx = command.indexOf(tag.rawTag());
+        if (idx >= 0) {
+          command =
+              command.substring(0, idx) + joined + command.substring(idx + tag.rawTag().length());
+        }
       } else {
         String replacement = answerIdx < answers.size() ? answers.get(answerIdx) : "";
-        command = command.replace(tag.rawTag(), replacement);
+        int idx = command.indexOf(tag.rawTag());
+        if (idx >= 0) {
+          command =
+              command.substring(0, idx)
+                  + replacement
+                  + command.substring(idx + tag.rawTag().length());
+        }
         answerIdx++;
       }
     }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/PostCommandMeta.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/PostCommandMeta.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -31,7 +32,15 @@ public record PostCommandMeta(
 
   public PostCommandMeta {
     Objects.requireNonNull(command);
+    Objects.requireNonNull(answerIndices);
     Objects.requireNonNull(dispatchTarget);
+    answerIndices = answerIndices.clone();
+  }
+
+  /** Returns a defensive copy so callers cannot mutate parsed session metadata. */
+  @Override
+  public int[] answerIndices() {
+    return answerIndices.clone();
   }
 
   /**
@@ -41,5 +50,23 @@ public record PostCommandMeta(
    */
   public boolean isPreset() {
     return preset;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) return true;
+    if (!(other instanceof PostCommandMeta that)) return false;
+    return delayTicks == that.delayTicks
+        && onCancel == that.onCancel
+        && preset == that.preset
+        && command.equals(that.command)
+        && Arrays.equals(answerIndices, that.answerIndices)
+        && dispatchTarget == that.dispatchTarget;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(command, delayTicks, onCancel, dispatchTarget, preset);
+    return 31 * result + Arrays.hashCode(answerIndices);
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/ConfigurationException.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/ConfigurationException.java
@@ -1,0 +1,19 @@
+package dev.cyr1en.promptcore.config;
+
+/**
+ * Thrown when a configuration document cannot be read, converted, or updated safely.
+ *
+ * <p>This is an {@link IllegalStateException} so callers that previously handled configuration
+ * failures as state errors remain source-compatible, while the dedicated type lets callers
+ * distinguish malformed configuration from unrelated programming errors.
+ */
+public class ConfigurationException extends IllegalStateException {
+
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/RecordConfigLoader.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/RecordConfigLoader.java
@@ -40,8 +40,6 @@ public class RecordConfigLoader {
             ? new String[] {configClass.getSimpleName(), "Configuration"}
             : headerAnnotation.value();
 
-    boolean saveNeeded = false;
-
     var configValues = new ArrayList<>();
     configValues.add(config);
 
@@ -62,7 +60,6 @@ public class RecordConfigLoader {
 
         if (nodeDefault != null) {
           handler.setValue(config, nodeName, nodeDefault, nodeComment);
-          saveNeeded = true;
         }
       } else {
         var commentAnnotation = field.getAnnotation(NodeComment.class);
@@ -74,7 +71,19 @@ public class RecordConfigLoader {
       if (field.isAnnotationPresent(Match.class)) {
         var matchAnnotation = field.getAnnotation(Match.class);
         var regex = matchAnnotation.regex();
-        var pattern = Pattern.compile(regex);
+        final Pattern pattern;
+        try {
+          pattern = Pattern.compile(regex);
+        } catch (RuntimeException e) {
+          throw new ConfigurationException(
+              "Invalid regex for configuration path '"
+                  + nodeName
+                  + "' in "
+                  + file.getAbsolutePath()
+                  + ": "
+                  + regex,
+              e);
+        }
         String valStr = config.getString(nodeName);
         if (valStr != null) {
           var res = pattern.matcher(valStr).matches();
@@ -101,15 +110,20 @@ public class RecordConfigLoader {
       }
     }
 
-    config.save(header);
-
     try {
       var recordConfig =
           configClass.getDeclaredConstructors()[0].newInstance(configValues.toArray());
       @SuppressWarnings("unchecked")
       var out = (T) recordConfig;
+      // Dump only after every value and the record constructor have validated successfully. A
+      // malformed value therefore cannot cause a partially defaulted configuration to be saved.
+      config.save(header);
       return out;
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException runtime) throw runtime;
+      throw new RuntimeException(
+          "Failed to instantiate config: " + configClass.getSimpleName(), e.getCause());
+    } catch (InstantiationException | IllegalAccessException e) {
       throw new RuntimeException("Failed to instantiate config: " + configClass.getSimpleName(), e);
     }
   }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/SnakeYamlDocument.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/SnakeYamlDocument.java
@@ -1,15 +1,24 @@
 package dev.cyr1en.promptcore.config;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.DuplicateKeyException;
+import org.yaml.snakeyaml.representer.Representer;
 
 public class SnakeYamlDocument implements YamlDocument {
 
@@ -18,23 +27,50 @@ public class SnakeYamlDocument implements YamlDocument {
   private final Map<String, String[]> commentsMap = new LinkedHashMap<>();
   private final Yaml yaml;
 
-  @SuppressWarnings("unchecked")
   public SnakeYamlDocument(File file) {
+    if (file == null) throw new IllegalArgumentException("Configuration file must not be null");
     this.file = file;
-    DumperOptions options = new DumperOptions();
-    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-    options.setIndent(2);
-    this.yaml = new Yaml(options);
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setAllowDuplicateKeys(false);
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+    dumperOptions.setIndent(2);
+    this.yaml =
+        new Yaml(
+            new Constructor(loaderOptions),
+            new Representer(dumperOptions),
+            dumperOptions,
+            loaderOptions);
 
-    Map<String, Object> loaded = null;
-    if (file.exists()) {
-      try (FileInputStream is = new FileInputStream(file)) {
-        loaded = yaml.load(is);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+    if (!file.exists()) {
+      this.data = new LinkedHashMap<>();
+      return;
     }
-    this.data = loaded != null ? loaded : new LinkedHashMap<>();
+
+    try (var reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+      Object loaded = yaml.load(reader);
+      if (loaded == null) {
+        this.data = new LinkedHashMap<>();
+      } else if (loaded instanceof Map<?, ?> map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> cast = (Map<String, Object>) map;
+        this.data = cast;
+      } else {
+        throw new ConfigurationException(
+            "Configuration file "
+                + file.getAbsolutePath()
+                + " must contain a YAML mapping at the root, but found "
+                + typeName(loaded));
+      }
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (DuplicateKeyException e) {
+      throw new ConfigurationException(
+          "Duplicate YAML key in configuration file " + file.getAbsolutePath() + ": " + e, e);
+    } catch (IOException | RuntimeException e) {
+      throw new ConfigurationException(
+          "Failed to read or parse configuration file " + file.getAbsolutePath(), e);
+    }
   }
 
   @Override
@@ -45,61 +81,150 @@ public class SnakeYamlDocument implements YamlDocument {
   @Override
   public String getString(String nodeName) {
     Object val = get(nodeName);
-    return val != null ? String.valueOf(val) : null;
+    if (val == null) return null;
+    if (val instanceof CharSequence || val instanceof Number || val instanceof Boolean) {
+      return String.valueOf(val);
+    }
+    throw valueError(nodeName, "a scalar string-compatible value", val);
   }
 
   @Override
   public int getInt(String nodeName) {
     Object val = get(nodeName);
-    if (val instanceof Number) return ((Number) val).intValue();
-    if (val instanceof String) return Integer.parseInt((String) val);
-    return 0;
+    if (val == null) return 0;
+
+    BigDecimal decimal;
+    if (val instanceof String string) {
+      try {
+        // Integer configuration values use an integer spelling. In particular, do not silently
+        // accept a fractional string and narrow it to an int.
+        return Integer.parseInt(string);
+      } catch (NumberFormatException e) {
+        throw valueError(nodeName, "an integer", val, e);
+      }
+    } else if (val instanceof BigDecimal bigDecimal) {
+      decimal = bigDecimal;
+    } else if (val instanceof BigInteger bigInteger) {
+      decimal = new BigDecimal(bigInteger);
+    } else if (val instanceof Double || val instanceof Float) {
+      double number = ((Number) val).doubleValue();
+      if (!Double.isFinite(number)) {
+        throw valueError(nodeName, "a finite integer", val);
+      }
+      decimal = BigDecimal.valueOf(number);
+    } else if (val instanceof Number number) {
+      try {
+        decimal = new BigDecimal(number.toString());
+      } catch (NumberFormatException e) {
+        throw valueError(nodeName, "an integer", val, e);
+      }
+    } else {
+      throw valueError(nodeName, "an integer", val);
+    }
+
+    if (decimal.stripTrailingZeros().scale() > 0
+        || decimal.compareTo(BigDecimal.valueOf(Integer.MIN_VALUE)) < 0
+        || decimal.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0) {
+      throw valueError(nodeName, "a finite 32-bit integer", val);
+    }
+    return decimal.intValueExact();
   }
 
   @Override
   public double getDouble(String nodeName) {
     Object val = get(nodeName);
-    if (val instanceof Number) return ((Number) val).doubleValue();
-    if (val instanceof String) return Double.parseDouble((String) val);
-    return 0.0;
+    if (val == null) return 0.0;
+
+    final double result;
+    if (val instanceof Number number) {
+      result = number.doubleValue();
+    } else if (val instanceof String string) {
+      try {
+        result = Double.parseDouble(string);
+      } catch (NumberFormatException e) {
+        throw valueError(nodeName, "a number", val, e);
+      }
+    } else {
+      throw valueError(nodeName, "a number", val);
+    }
+    if (!Double.isFinite(result)) {
+      throw valueError(nodeName, "a finite number", val);
+    }
+    return result;
   }
 
   @Override
   public boolean getBoolean(String nodeName) {
     Object val = get(nodeName);
     if (val instanceof Boolean) return (Boolean) val;
-    if (val instanceof String) return Boolean.parseBoolean((String) val);
-    return false;
+    if (val == null) return false;
+    if (val instanceof String string
+        && (string.equalsIgnoreCase("true") || string.equalsIgnoreCase("false"))) {
+      return Boolean.parseBoolean(string);
+    }
+    throw valueError(nodeName, "the boolean literal true or false", val);
   }
 
   @Override
   public List<?> getList(String nodeName) {
     Object val = get(nodeName);
-    if (val instanceof List) return (List<?>) val;
-    return null;
+    if (val == null) return List.of();
+    if (val instanceof List<?> list) {
+      for (Object element : list) {
+        if (element == null) {
+          throw valueError(nodeName, "a list without null elements", list);
+        }
+      }
+      return List.copyOf(list);
+    }
+    throw valueError(nodeName, "a YAML list", val);
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public Set<String> getKeys(String nodeName) {
     Object val = get(nodeName);
-    if (val instanceof Map) {
-      return ((Map<String, Object>) val).keySet();
+    if (val instanceof Map<?, ?> map) {
+      var keys = new LinkedHashSet<String>();
+      for (Object key : map.keySet()) {
+        if (!(key instanceof String stringKey)) {
+          throw valueError(nodeName, "a mapping with string keys", key);
+        }
+        keys.add(stringKey);
+      }
+      return java.util.Collections.unmodifiableSet(keys);
     }
     return Set.of();
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void set(String nodeName, Object value, String[] comments) {
     setComments(nodeName, comments);
 
-    String[] parts = nodeName.split("\\.");
+    String[] parts = splitPath(nodeName);
     Map<String, Object> current = data;
     for (int i = 0; i < parts.length - 1; i++) {
-      current =
-          (Map<String, Object>)
-              current.computeIfAbsent(parts[i], k -> new LinkedHashMap<String, Object>());
+      Object next = current.get(parts[i]);
+      if (next == null) {
+        var child = new LinkedHashMap<String, Object>();
+        current.put(parts[i], child);
+        current = child;
+      } else if (next instanceof Map<?, ?> map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> child = (Map<String, Object>) map;
+        current = child;
+      } else {
+        String parentPath = String.join(".", java.util.Arrays.copyOf(parts, i + 1));
+        throw new ConfigurationException(
+            "Cannot set configuration path '"
+                + nodeName
+                + "' in "
+                + file.getAbsolutePath()
+                + ": parent path '"
+                + parentPath
+                + "' contains "
+                + typeName(next)
+                + " instead of a mapping");
+      }
     }
     current.put(parts[parts.length - 1], value);
   }
@@ -111,88 +236,171 @@ public class SnakeYamlDocument implements YamlDocument {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private Object getNested(String nodeName) {
-    String[] parts = nodeName.split("\\.");
+    String[] parts = splitPath(nodeName);
     Map<String, Object> current = data;
     for (int i = 0; i < parts.length - 1; i++) {
       Object next = current.get(parts[i]);
-      if (!(next instanceof Map)) return null;
-      current = (Map<String, Object>) next;
+      if (next == null) return null;
+      if (!(next instanceof Map<?, ?> map)) {
+        String parentPath = String.join(".", java.util.Arrays.copyOf(parts, i + 1));
+        throw new ConfigurationException(
+            "Cannot read configuration path '"
+                + nodeName
+                + "' in "
+                + file.getAbsolutePath()
+                + ": parent path '"
+                + parentPath
+                + "' contains "
+                + typeName(next)
+                + " instead of a mapping");
+      }
+      @SuppressWarnings("unchecked")
+      Map<String, Object> child = (Map<String, Object>) map;
+      current = child;
     }
     return current.get(parts[parts.length - 1]);
   }
 
   public void save(String[] header) {
-    try {
-      if (!file.getParentFile().exists()) {
-        file.getParentFile().mkdirs();
-      }
-      try (FileWriter writer = new FileWriter(file)) {
-        if (header != null) {
-          for (String line : header) {
-            writer.write("# " + line + "\n");
+    String rawDump = yaml.dump(data);
+    // Space out top-level sections
+    rawDump = rawDump.replaceAll("(?m)^([a-zA-Z0-9_-]+:)", "\n$1");
+    // Remove leading newlines
+    rawDump = rawDump.replaceFirst("^\\n+", "");
+
+    for (Map.Entry<String, String[]> entry : commentsMap.entrySet()) {
+      String fullKey = entry.getKey();
+      String[] parts = fullKey.split("\\.");
+      int searchIndex = 0;
+      int matchStart = -1;
+      String indent = "";
+
+      boolean found = true;
+      for (int i = 0; i < parts.length; i++) {
+        // Default indentation is 2 spaces
+        String expectedIndent = " ".repeat(i * 2);
+        java.util.regex.Pattern p =
+            java.util.regex.Pattern.compile(
+                "(?m)^(" + expectedIndent + ")" + java.util.regex.Pattern.quote(parts[i]) + ":");
+        java.util.regex.Matcher m = p.matcher(rawDump);
+
+        if (m.find(searchIndex)) {
+          searchIndex = m.start() + 1;
+          if (i == parts.length - 1) {
+            matchStart = m.start();
+            indent = m.group(1);
           }
-          if (header.length > 0) writer.write("\n");
+        } else {
+          found = false;
+          break;
         }
+      }
 
-        String rawDump = yaml.dump(data);
-
-        // Space out top-level sections
-        rawDump = rawDump.replaceAll("(?m)^([a-zA-Z0-9_-]+:)", "\n$1");
-        // Remove leading newlines
-        rawDump = rawDump.replaceFirst("^\\n+", "");
-
-        for (Map.Entry<String, String[]> entry : commentsMap.entrySet()) {
-          String fullKey = entry.getKey();
-          String[] parts = fullKey.split("\\.");
-          int searchIndex = 0;
-          int matchStart = -1;
-          String indent = "";
-
-          boolean found = true;
-          for (int i = 0; i < parts.length; i++) {
-            // Default indentation is 2 spaces
-            String expectedIndent = " ".repeat(i * 2);
-            java.util.regex.Pattern p =
-                java.util.regex.Pattern.compile(
-                    "(?m)^("
-                        + expectedIndent
-                        + ")"
-                        + java.util.regex.Pattern.quote(parts[i])
-                        + ":");
-            java.util.regex.Matcher m = p.matcher(rawDump);
-
-            if (m.find(searchIndex)) {
-              searchIndex = m.start() + 1;
-              if (i == parts.length - 1) {
-                matchStart = m.start();
-                indent = m.group(1);
-              }
-            } else {
-              found = false;
-              break;
-            }
-          }
-
-          if (found && matchStart != -1) {
-            StringBuilder commentsStr = new StringBuilder();
-            for (String c : entry.getValue()) {
-              if (c != null && !c.isEmpty()) {
-                commentsStr.append(indent).append("# ").append(c).append("\n");
-              }
-            }
-            rawDump =
-                rawDump.substring(0, matchStart)
-                    + commentsStr.toString()
-                    + rawDump.substring(matchStart);
+      if (found && matchStart != -1) {
+        StringBuilder commentsStr = new StringBuilder();
+        for (String c : entry.getValue()) {
+          if (c != null && !c.isEmpty()) {
+            commentsStr.append(indent).append("# ").append(c).append("\n");
           }
         }
-
-        writer.write(rawDump);
+        rawDump = rawDump.substring(0, matchStart) + commentsStr + rawDump.substring(matchStart);
       }
-    } catch (IOException e) {
-      e.printStackTrace();
     }
+
+    StringBuilder output = new StringBuilder();
+    if (header != null) {
+      for (String line : header) {
+        output.append("# ").append(line).append('\n');
+      }
+      if (header.length > 0) output.append('\n');
+    }
+    output.append(rawDump);
+
+    Path temporary = null;
+    ConfigurationException saveFailure = null;
+    try {
+      Path target = file.toPath().toAbsolutePath();
+      Path parent = target.getParent();
+      if (parent == null) {
+        throw new IOException("Configuration file has no parent directory: " + target);
+      }
+      Files.createDirectories(parent);
+      temporary = Files.createTempFile(parent, file.getName() + ".", ".tmp");
+      try (var writer = Files.newBufferedWriter(temporary, StandardCharsets.UTF_8)) {
+        writer.write(output.toString());
+        writer.flush();
+      }
+
+      try {
+        Files.move(
+            temporary,
+            target,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException | UnsupportedOperationException e) {
+        Files.move(temporary, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      }
+      temporary = null;
+    } catch (IOException e) {
+      saveFailure =
+          new ConfigurationException(
+              "Failed to atomically save configuration file " + file.getAbsolutePath(), e);
+      throw saveFailure;
+    } finally {
+      if (temporary != null) {
+        try {
+          Files.deleteIfExists(temporary);
+        } catch (IOException cleanupFailure) {
+          if (saveFailure != null) {
+            saveFailure.addSuppressed(cleanupFailure);
+          } else {
+            throw new ConfigurationException(
+                "Failed to remove temporary configuration file " + temporary, cleanupFailure);
+          }
+        }
+      }
+    }
+  }
+
+  private static String[] splitPath(String nodeName) {
+    if (nodeName == null || nodeName.isBlank()) {
+      throw new IllegalArgumentException("Configuration path must not be blank");
+    }
+    String[] parts = nodeName.split("\\.", -1);
+    for (String part : parts) {
+      if (part.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Configuration path contains an empty segment: " + nodeName);
+      }
+    }
+    return parts;
+  }
+
+  private ConfigurationException valueError(String nodeName, String expected, Object actual) {
+    return valueError(nodeName, expected, actual, null);
+  }
+
+  private ConfigurationException valueError(
+      String nodeName, String expected, Object actual, Throwable cause) {
+    String message =
+        "Invalid value for configuration path '"
+            + nodeName
+            + "' in "
+            + file.getAbsolutePath()
+            + ": expected "
+            + expected
+            + ", got "
+            + typeName(actual)
+            + " ("
+            + String.valueOf(actual)
+            + ")";
+    return cause == null
+        ? new ConfigurationException(message)
+        : new ConfigurationException(message, cause);
+  }
+
+  private static String typeName(Object value) {
+    return value == null ? "null" : value.getClass().getName();
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/ConfigTypeHandlerFactory.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/ConfigTypeHandlerFactory.java
@@ -16,10 +16,14 @@ public class ConfigTypeHandlerFactory {
 
   static {
     handlers.put(int.class, new IntegerHandler());
+    handlers.put(Integer.class, new IntegerHandler());
     handlers.put(boolean.class, new BooleanHandler());
+    handlers.put(Boolean.class, new BooleanHandler());
     handlers.put(String.class, new StringHandler());
     handlers.put(double.class, new DoubleHandler());
+    handlers.put(Double.class, new DoubleHandler());
     handlers.put(float.class, new FloatHandler());
+    handlers.put(Float.class, new FloatHandler());
     handlers.put(List.class, new ListHandler());
   }
 

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/BooleanHandler.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/BooleanHandler.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore.config.handlers.impl;
 
+import dev.cyr1en.promptcore.config.ConfigurationException;
 import dev.cyr1en.promptcore.config.YamlDocument;
 import dev.cyr1en.promptcore.config.annotations.field.NodeDefault;
 import dev.cyr1en.promptcore.config.handlers.ConfigTypeHandler;
@@ -9,7 +10,14 @@ import java.lang.reflect.Field;
 public class BooleanHandler implements ConfigTypeHandler<Boolean> {
   @Override
   public Boolean getValue(YamlDocument config, String nodeName, Field field) {
-    return config.getBoolean(nodeName);
+    try {
+      return config.getBoolean(nodeName);
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ConfigurationException(
+          "Invalid boolean configuration value for '" + nodeName + "'", e);
+    }
   }
 
   @Override
@@ -20,6 +28,12 @@ public class BooleanHandler implements ConfigTypeHandler<Boolean> {
   @Override
   public Boolean getDefault(Field field) {
     var defaultAnnotation = field.getAnnotation(NodeDefault.class);
-    return defaultAnnotation != null && Boolean.parseBoolean(defaultAnnotation.value());
+    if (defaultAnnotation == null) return false;
+    var value = defaultAnnotation.value();
+    if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
+      throw new IllegalArgumentException(
+          "Invalid boolean default for '" + field.getName() + "': " + value);
+    }
+    return Boolean.parseBoolean(value);
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/DoubleHandler.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/DoubleHandler.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore.config.handlers.impl;
 
+import dev.cyr1en.promptcore.config.ConfigurationException;
 import dev.cyr1en.promptcore.config.YamlDocument;
 import dev.cyr1en.promptcore.config.annotations.field.NodeDefault;
 import dev.cyr1en.promptcore.config.handlers.ConfigTypeHandler;
@@ -9,7 +10,14 @@ import java.lang.reflect.Field;
 public class DoubleHandler implements ConfigTypeHandler<Double> {
   @Override
   public Double getValue(YamlDocument config, String nodeName, Field field) {
-    return config.getDouble(nodeName);
+    try {
+      return config.getDouble(nodeName);
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ConfigurationException(
+          "Invalid double configuration value for '" + nodeName + "'", e);
+    }
   }
 
   @Override
@@ -22,9 +30,15 @@ public class DoubleHandler implements ConfigTypeHandler<Double> {
     var defaultAnnotation = field.getAnnotation(NodeDefault.class);
     if (defaultAnnotation != null) {
       try {
-        return Double.parseDouble(defaultAnnotation.value());
+        var value = Double.parseDouble(defaultAnnotation.value());
+        if (!Double.isFinite(value)) {
+          throw new NumberFormatException("non-finite value");
+        }
+        return value;
       } catch (NumberFormatException e) {
-        return 0.0;
+        throw new IllegalArgumentException(
+            "Invalid double default for '" + field.getName() + "': " + defaultAnnotation.value(),
+            e);
       }
     }
     return 0.0;

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/FloatHandler.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/FloatHandler.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore.config.handlers.impl;
 
+import dev.cyr1en.promptcore.config.ConfigurationException;
 import dev.cyr1en.promptcore.config.YamlDocument;
 import dev.cyr1en.promptcore.config.annotations.field.NodeDefault;
 import dev.cyr1en.promptcore.config.handlers.ConfigTypeHandler;
@@ -9,7 +10,25 @@ import java.lang.reflect.Field;
 public class FloatHandler implements ConfigTypeHandler<Float> {
   @Override
   public Float getValue(YamlDocument config, String nodeName, Field field) {
-    return (float) config.getDouble(nodeName);
+    final double value;
+    try {
+      value = config.getDouble(nodeName);
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ConfigurationException(
+          "Invalid float configuration value for '" + nodeName + "'", e);
+    }
+    float narrowed = (float) value;
+    if (!Float.isFinite(narrowed)) {
+      throw new ConfigurationException(
+          "Invalid float configuration value for '"
+              + nodeName
+              + "': value overflows a 32-bit float ("
+              + value
+              + ")");
+    }
+    return narrowed;
   }
 
   @Override
@@ -22,9 +41,14 @@ public class FloatHandler implements ConfigTypeHandler<Float> {
     var defaultAnnotation = field.getAnnotation(NodeDefault.class);
     if (defaultAnnotation != null) {
       try {
-        return Float.parseFloat(defaultAnnotation.value());
+        var value = Float.parseFloat(defaultAnnotation.value());
+        if (!Float.isFinite(value)) {
+          throw new NumberFormatException("non-finite value");
+        }
+        return value;
       } catch (NumberFormatException e) {
-        return 0.0f;
+        throw new IllegalArgumentException(
+            "Invalid float default for '" + field.getName() + "': " + defaultAnnotation.value(), e);
       }
     }
     return 0.0f;

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/IntegerHandler.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/IntegerHandler.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore.config.handlers.impl;
 
+import dev.cyr1en.promptcore.config.ConfigurationException;
 import dev.cyr1en.promptcore.config.YamlDocument;
 import dev.cyr1en.promptcore.config.annotations.field.IntegerConstraint;
 import dev.cyr1en.promptcore.config.annotations.field.NodeDefault;
@@ -12,10 +13,21 @@ import java.lang.reflect.Field;
 public class IntegerHandler implements ConfigTypeHandler<Integer> {
   @Override
   public Integer getValue(YamlDocument config, String nodeName, Field field) {
-    int val = config.getInt(nodeName);
+    final int val;
+    try {
+      val = config.getInt(nodeName);
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ConfigurationException(
+          "Invalid integer configuration value for '" + nodeName + "'", e);
+    }
+    int constrained = val;
     IntegerConstraint constraint = field.getAnnotation(IntegerConstraint.class);
-    if (constraint != null) val = Math.min(Math.max(val, constraint.min()), constraint.max());
-    return val;
+    if (constraint != null) {
+      constrained = Math.min(Math.max(constrained, constraint.min()), constraint.max());
+    }
+    return constrained;
   }
 
   @Override
@@ -30,7 +42,9 @@ public class IntegerHandler implements ConfigTypeHandler<Integer> {
       try {
         return Integer.parseInt(defaultAnnotation.value());
       } catch (NumberFormatException e) {
-        return 0;
+        throw new IllegalArgumentException(
+            "Invalid integer default for '" + field.getName() + "': " + defaultAnnotation.value(),
+            e);
       }
     }
     return 0;

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/ListHandler.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/config/handlers/impl/ListHandler.java
@@ -1,9 +1,11 @@
 package dev.cyr1en.promptcore.config.handlers.impl;
 
+import dev.cyr1en.promptcore.config.ConfigurationException;
 import dev.cyr1en.promptcore.config.YamlDocument;
 import dev.cyr1en.promptcore.config.annotations.field.NodeDefault;
 import dev.cyr1en.promptcore.config.handlers.ConfigTypeHandler;
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 
 /**
@@ -13,7 +15,46 @@ import java.util.List;
 public class ListHandler implements ConfigTypeHandler<List<?>> {
   @Override
   public List<?> getValue(YamlDocument config, String nodeName, Field field) {
-    return config.getList(nodeName);
+    final List<?> value;
+    try {
+      value = config.getList(nodeName);
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new ConfigurationException(
+          "Invalid list configuration value for '" + nodeName + "'", e);
+    }
+    if (value == null) {
+      throw new ConfigurationException(
+          "Invalid list configuration value for '" + nodeName + "': list must not be null");
+    }
+
+    var elementType = elementType(field);
+    for (var element : value) {
+      if (element == null) {
+        throw new ConfigurationException(
+            "Invalid list configuration value for '"
+                + nodeName
+                + "': list elements must not be null");
+      }
+      if (element instanceof List<?> || element instanceof java.util.Map<?, ?>) {
+        throw new ConfigurationException(
+            "Invalid list configuration value for '"
+                + nodeName
+                + "': expected scalar elements, got "
+                + element.getClass().getName());
+      }
+      if (elementType != null && !elementType.isInstance(element)) {
+        throw new ConfigurationException(
+            "Invalid list configuration value for '"
+                + nodeName
+                + "': expected elements of type "
+                + elementType.getTypeName()
+                + ", got "
+                + element.getClass().getName());
+      }
+    }
+    return List.copyOf(value);
   }
 
   @Override
@@ -27,5 +68,11 @@ public class ListHandler implements ConfigTypeHandler<List<?>> {
     if (defaultAnnotation != null)
       return List.of(defaultAnnotation.value().split(",")).stream().map(String::trim).toList();
     return List.of();
+  }
+
+  private static Class<?> elementType(Field field) {
+    if (!(field.getGenericType() instanceof ParameterizedType parameterized)) return null;
+    var argument = parameterized.getActualTypeArguments()[0];
+    return argument instanceof Class<?> clazz ? clazz : null;
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/i18n/AbstractI18n.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/i18n/AbstractI18n.java
@@ -39,7 +39,10 @@ public abstract class AbstractI18n<T, C> {
   protected final String locale;
   protected final File baseDir;
   protected final ClassLoader pluginClassLoader;
-  protected final Properties merged;
+
+  /** Immutable-after-publication snapshot; the reference is swapped atomically on reload. */
+  protected volatile Properties merged;
+
   protected final Logger logger;
 
   /**
@@ -57,7 +60,7 @@ public abstract class AbstractI18n<T, C> {
     this.pluginClassLoader = pluginClassLoader;
     this.merged = new Properties();
     this.logger = logger;
-    load();
+    reload();
   }
 
   public String getLocale() {
@@ -77,7 +80,8 @@ public abstract class AbstractI18n<T, C> {
    * @return the formatted result, or a fallback value if the key is missing
    */
   public T get(String key, C context, Placeholder... placeholders) {
-    var raw = merged.getProperty(key);
+    var snapshot = merged;
+    var raw = snapshot.getProperty(key);
     if (raw == null) {
       return missing(key);
     }
@@ -103,8 +107,19 @@ public abstract class AbstractI18n<T, C> {
    * without a full server restart.
    */
   public void reload() {
-    merged.clear();
-    load();
+    try {
+      // Build everything off to the side. Properties is mutable, so publishing a single fully
+      // loaded instance is essential: clearing and repopulating the live object exposes partial
+      // translations to scheduler threads.
+      merged = loadSnapshot();
+    } catch (RuntimeException e) {
+      if (logger != null) {
+        logger.warning("[I18n] Reload failed for locale " + locale + ": " + e.getMessage());
+      }
+      // Keep the old snapshot visible and let the caller decide whether the overall config reload
+      // should fail. No reader can observe a partially loaded set.
+      throw e;
+    }
   }
 
   /**
@@ -162,44 +177,52 @@ public abstract class AbstractI18n<T, C> {
    * Populates {@link #merged} using the three-level fallback chain. Later levels take priority, so
    * user-override properties are loaded last and overwrite JAR-provided defaults.
    */
-  private void load() {
+  private Properties loadSnapshot() {
+    var snapshot = new Properties();
     // Ultimate JAR fallback (en_US)
-    loadFromJar("messages_en_US.properties");
+    loadFromJar(snapshot, "messages_en_US.properties");
 
     // Locale-specific JAR bundle
     if (!"en_US".equals(locale)) {
-      loadFromJar("messages_" + locale + ".properties");
+      loadFromJar(snapshot, "messages_" + locale + ".properties");
     }
 
     // User-override file on disk (highest priority)
-    loadFromDisk(locale);
+    loadFromDisk(snapshot, locale);
+    return snapshot;
   }
 
-  private void loadFromJar(String resourceName) {
+  private void loadFromJar(Properties snapshot, String resourceName) {
     try (InputStream in = pluginClassLoader.getResourceAsStream(resourceName)) {
       if (in == null) return;
       try (var reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
-        merged.load(reader);
+        loadProperties(snapshot, reader, "classpath:" + resourceName);
       }
     } catch (IOException e) {
-      if (logger != null) {
-        logger.warning("[I18n] Failed to load bundled " + resourceName + ": " + e.getMessage());
-      }
+      throw new IllegalStateException(
+          "Failed to load bundled properties classpath:" + resourceName, e);
     }
   }
 
-  private void loadFromDisk(String locale) {
+  private void loadFromDisk(Properties snapshot, String locale) {
     var localesDir = new File(baseDir, LOCALES_DIR);
     var overrideFile = new File(localesDir, "messages_" + locale + ".properties");
     if (!overrideFile.exists()) return;
     try (var reader =
         new InputStreamReader(new FileInputStream(overrideFile), StandardCharsets.UTF_8)) {
-      merged.load(reader);
+      loadProperties(snapshot, reader, overrideFile.getAbsolutePath());
     } catch (IOException e) {
-      if (logger != null) {
-        logger.warning(
-            "[I18n] Failed to load override " + overrideFile.getName() + ": " + e.getMessage());
-      }
+      throw new IllegalStateException(
+          "Failed to load override properties " + overrideFile.getAbsolutePath(), e);
+    }
+  }
+
+  private static void loadProperties(Properties snapshot, InputStreamReader reader, String source)
+      throws IOException {
+    try {
+      snapshot.load(reader);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Malformed properties in " + source, e);
     }
   }
 }

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/parser/CommandLineParser.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/parser/CommandLineParser.java
@@ -75,11 +75,18 @@ public class CommandLineParser {
     String escPattern = Pattern.quote(config.escape());
     this.tagPattern =
         Pattern.compile(
-            "(?<!" + escPattern + ")" + Pattern.quote(open) + "(.*?)" + Pattern.quote(close));
+            "(?<!"
+                + escPattern
+                + ")"
+                + Pattern.quote(open)
+                + "(.*?)(?<!"
+                + escPattern
+                + ")"
+                + Pattern.quote(close));
     this.pcmPrefix = Pattern.compile("^!");
     this.pcmCancelPrefix = Pattern.compile("^!!");
     this.pcmDelay = Pattern.compile("^!:(\\d+)");
-    this.pcmTarget = Pattern.compile("@(console|player)");
+    this.pcmTarget = Pattern.compile("@(console|player)(?=\\s|$)");
     this.answerRef = Pattern.compile("\\{(\\d+)}");
     this.validatorFlag = Pattern.compile("-iv:(\\w+)");
     this.dsFlag = Pattern.compile("-ds\\b");
@@ -189,7 +196,12 @@ public class CommandLineParser {
         end++;
       }
       if (end > 1) {
-        delay = Integer.parseInt(content.substring(1, end));
+        try {
+          delay = Integer.parseInt(content.substring(1, end));
+        } catch (NumberFormatException e) {
+          LOG.warning("PCM delay value too large, ignoring: " + content.substring(1, end));
+          delay = 0;
+        }
         content = content.substring(end);
       }
     }
@@ -226,7 +238,11 @@ public class CommandLineParser {
     var indices = new ArrayList<Integer>();
     var refMatcher = answerRef.matcher(content);
     while (refMatcher.find()) {
-      indices.add(Integer.parseInt(refMatcher.group(1)));
+      try {
+        indices.add(Integer.parseInt(refMatcher.group(1)));
+      } catch (NumberFormatException e) {
+        LOG.warning("Answer reference index too large, ignoring: " + refMatcher.group(1));
+      }
     }
 
     // Clean up command text
@@ -373,6 +389,24 @@ public class CommandLineParser {
     return false;
   }
 
+  private static List<String> splitCompound(String s) {
+    var parts = new ArrayList<String>();
+    var depth = 0;
+    var start = 0;
+    for (var i = 0; i < s.length() - 1; i++) {
+      var c = s.charAt(i);
+      if (c == '[') depth++;
+      else if (c == ']') depth--;
+      else if (depth == 0 && c == '&' && s.charAt(i + 1) == '&') {
+        parts.add(s.substring(start, i));
+        i++;
+        start = i + 1;
+      }
+    }
+    parts.add(s.substring(start));
+    return parts;
+  }
+
   /**
    * Parse a compound dialog tag ({@code <d:filter1:disp1 && d:filter2:disp2>}). Block-level flags
    * are extracted first and stripped before splitting on {@code &&}.
@@ -394,7 +428,7 @@ public class CommandLineParser {
             .replaceAll("-str\\b", "")
             .trim();
 
-    var subContents = stripped.split("&&");
+    var subContents = splitCompound(stripped);
     var subTags = new ArrayList<PromptTag>();
     for (var sub : subContents) {
       var trimmed = sub.trim();

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/parser/CommandLineParser.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/parser/CommandLineParser.java
@@ -4,7 +4,6 @@ import dev.cyr1en.promptcore.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -26,10 +25,6 @@ public class CommandLineParser {
 
   private final ParserConfig config;
   private final TagFilter tagFilter;
-  private final Pattern tagPattern;
-  private final Pattern pcmPrefix;
-  private final Pattern pcmCancelPrefix;
-  private final Pattern pcmDelay;
   private final Pattern pcmTarget;
   private final Pattern answerRef;
   private final Pattern validatorFlag;
@@ -70,29 +65,14 @@ public class CommandLineParser {
   public CommandLineParser(ParserConfig config, TagFilter tagFilter) {
     this.config = config;
     this.tagFilter = tagFilter;
-    String open = config.opening();
-    String close = config.closing();
-    String escPattern = Pattern.quote(config.escape());
-    this.tagPattern =
-        Pattern.compile(
-            "(?<!"
-                + escPattern
-                + ")"
-                + Pattern.quote(open)
-                + "(.*?)(?<!"
-                + escPattern
-                + ")"
-                + Pattern.quote(close));
-    this.pcmPrefix = Pattern.compile("^!");
-    this.pcmCancelPrefix = Pattern.compile("^!!");
-    this.pcmDelay = Pattern.compile("^!:(\\d+)");
-    this.pcmTarget = Pattern.compile("@(console|player)(?=\\s|$)");
+    this.pcmTarget = Pattern.compile("(?<!\\S)@(console|player)(?=\\s|$)");
     this.answerRef = Pattern.compile("\\{(\\d+)}");
-    this.validatorFlag = Pattern.compile("-iv:(\\w+)");
-    this.dsFlag = Pattern.compile("-ds\\b");
-    this.intFlag = Pattern.compile("-int\\b");
-    this.strFlag = Pattern.compile("-str\\b");
-    this.titleFlag = Pattern.compile("-t(?:\\b|(?=:))(?::(?:[^\"\\s]+|\"[^\"]*\")*)?");
+    // Flags are tokens, not substrings of display text (for example, cost-int).
+    this.validatorFlag = Pattern.compile("(?<!\\S)-iv:(\\w+)(?!\\S)");
+    this.dsFlag = Pattern.compile("(?<!\\S)-ds(?!\\S)");
+    this.intFlag = Pattern.compile("(?<!\\S)-int(?!\\S)");
+    this.strFlag = Pattern.compile("(?<!\\S)-str(?!\\S)");
+    this.titleFlag = Pattern.compile("(?<!\\S)-t(?:\\b|(?=:))(?::(?:[^\"\\s]+|\"[^\"]*\")*)?");
   }
 
   /** Returns the {@link ParserConfig} used by this parser. */
@@ -115,15 +95,15 @@ public class CommandLineParser {
       return new ParsedCommand(rawCommand == null ? "" : rawCommand, List.of(), List.of(), config);
     }
 
-    var matcher = tagPattern.matcher(rawCommand);
     var promptTags = new ArrayList<PromptTag>();
     var postCmds = new ArrayList<PostCommandMeta>();
+    var spans = new ArrayList<ParsedCommand.TemplateSpan>();
 
     LOG.fine("Parsing command: " + rawCommand);
 
-    while (matcher.find()) {
-      var rawContent = matcher.group(1);
-      var fullTag = config.opening() + rawContent + config.closing();
+    for (var match : scanTags(rawCommand)) {
+      var rawContent = match.content();
+      var fullTag = match.rawText();
 
       // Skip tags that the filter says to ignore (e.g. MiniMessage syntax).
       if (tagFilter != null && tagFilter.test(rawContent)) {
@@ -133,8 +113,17 @@ public class CommandLineParser {
 
       if (isPCM(rawContent)) {
         parsePCM(rawContent, fullTag, postCmds);
+        spans.add(
+            new ParsedCommand.TemplateSpan(
+                match.start(), match.end(), match.rawText(), true, postCmds.size() - 1));
       } else {
+        int before = promptTags.size();
         parsePromptTag(rawContent, fullTag, promptTags);
+        if (promptTags.size() > before) {
+          spans.add(
+              new ParsedCommand.TemplateSpan(
+                  match.start(), match.end(), match.rawText(), false, promptTags.size() - 1));
+        }
       }
     }
 
@@ -146,7 +135,9 @@ public class CommandLineParser {
         template,
         Collections.unmodifiableList(promptTags),
         Collections.unmodifiableList(postCmds),
-        config);
+        config,
+        rawCommand,
+        Collections.unmodifiableList(spans));
   }
 
   /**
@@ -159,10 +150,8 @@ public class CommandLineParser {
    */
   public boolean hasTagForm(String rawCommand) {
     if (rawCommand == null || rawCommand.isBlank()) return false;
-    var matcher = tagPattern.matcher(rawCommand);
-    while (matcher.find()) {
-      var rawContent = matcher.group(1);
-      if (tagFilter == null || !tagFilter.test(rawContent)) {
+    for (var match : scanTags(rawCommand)) {
+      if (tagFilter == null || !tagFilter.test(match.content())) {
         return true;
       }
     }
@@ -175,8 +164,57 @@ public class CommandLineParser {
   }
 
   private boolean isPCM(String content) {
-    return pcmPrefix.matcher(content).find();
+    return content.startsWith("!");
   }
+
+  /**
+   * Scans delimiter pairs in one pass. An escape consumes the following character, and an
+   * unterminated opener consumes the remainder of the input rather than restarting a search at
+   * every later opener. That makes repeated unterminated openers linear instead of quadratic.
+   */
+  private List<TagMatch> scanTags(String rawCommand) {
+    var matches = new ArrayList<TagMatch>();
+    char opening = config.opening().charAt(0);
+    char closing = config.closing().charAt(0);
+    char escape = config.escape().charAt(0);
+    int i = 0;
+    while (i < rawCommand.length()) {
+      char current = rawCommand.charAt(i);
+      if (current == escape) {
+        i += i + 1 < rawCommand.length() ? 2 : 1;
+        continue;
+      }
+      if (current != opening) {
+        i++;
+        continue;
+      }
+
+      int start = i++;
+      boolean closed = false;
+      while (i < rawCommand.length()) {
+        current = rawCommand.charAt(i);
+        if (current == escape) {
+          i += i + 1 < rawCommand.length() ? 2 : 1;
+        } else if (current == closing) {
+          int end = ++i;
+          matches.add(
+              new TagMatch(
+                  start,
+                  end,
+                  rawCommand.substring(start + 1, end - 1),
+                  rawCommand.substring(start, end)));
+          closed = true;
+          break;
+        } else {
+          i++;
+        }
+      }
+      if (!closed) break;
+    }
+    return matches;
+  }
+
+  private record TagMatch(int start, int end, String content, String rawText) {}
 
   private void parsePCM(String rawContent, String fullTag, List<PostCommandMeta> postCmds) {
     var content = rawContent;
@@ -225,13 +263,11 @@ public class CommandLineParser {
     // Extract dispatch target (@console / @player)
     var target = DispatchTarget.PASSTHROUGH;
     var targetMatcher = pcmTarget.matcher(content);
-    var newContent = targetMatcher.replaceFirst("");
-    if (newContent.length() != content.length()) {
-      targetMatcher.reset();
-      if (targetMatcher.find()) {
-        target = DispatchTarget.valueOf(targetMatcher.group(1).toUpperCase(Locale.ROOT));
-      }
-      content = newContent.trim();
+    if (targetMatcher.find()) {
+      target = DispatchTarget.valueOf(targetMatcher.group(1).toUpperCase(Locale.ROOT));
+      content =
+          (content.substring(0, targetMatcher.start()) + content.substring(targetMatcher.end()))
+              .trim();
     }
 
     // Extract answer references ({N})
@@ -334,9 +370,9 @@ public class CommandLineParser {
     var displayText =
         unescape(
                 remainder
-                    .replaceAll("-iv:\\w+", "")
-                    .replaceAll("-int\\b", "")
-                    .replaceAll("-str\\b", ""))
+                    .replaceAll(validatorFlag.pattern(), "")
+                    .replaceAll(intFlag.pattern(), "")
+                    .replaceAll(strFlag.pattern(), ""))
             .trim();
 
     LOG.fine(
@@ -423,9 +459,9 @@ public class CommandLineParser {
     // Strip flags from the compound tag content.
     var stripped =
         stripTitleFlag(contentWithoutDs, title)
-            .replaceAll("-iv:\\w+", "")
-            .replaceAll("-int\\b", "")
-            .replaceAll("-str\\b", "")
+            .replaceAll(validatorFlag.pattern(), "")
+            .replaceAll(intFlag.pattern(), "")
+            .replaceAll(strFlag.pattern(), "")
             .trim();
 
     var subContents = splitCompound(stripped);
@@ -630,12 +666,23 @@ public class CommandLineParser {
 
   private String unescape(String input) {
     if (input == null || input.isEmpty()) return input;
-    var esc = Pattern.quote(config.escape());
-    return input
-        .replaceAll(
-            esc + Pattern.quote(config.opening()), Matcher.quoteReplacement(config.opening()))
-        .replaceAll(
-            esc + Pattern.quote(config.closing()), Matcher.quoteReplacement(config.closing()));
+    char escape = config.escape().charAt(0);
+    char opening = config.opening().charAt(0);
+    char closing = config.closing().charAt(0);
+    var result = new StringBuilder(input.length());
+    for (int i = 0; i < input.length(); i++) {
+      char current = input.charAt(i);
+      if (current == escape && i + 1 < input.length()) {
+        char next = input.charAt(i + 1);
+        if (next == opening || next == closing) {
+          result.append(next);
+          i++;
+          continue;
+        }
+      }
+      result.append(current);
+    }
+    return result.toString();
   }
 
   /**

--- a/prompt-core/src/main/java/dev/cyr1en/promptcore/session/PromptSession.java
+++ b/prompt-core/src/main/java/dev/cyr1en/promptcore/session/PromptSession.java
@@ -153,7 +153,7 @@ public final class PromptSession {
 
     var current = remaining.get(0);
     var processedAnswer = current.sanitize() ? sanitize(answer) : answer;
-    var newAnswers = new ArrayList<>(answers);
+    var newAnswers = new ArrayList<>(this.answers);
     newAnswers.add(processedAnswer);
     var newRemaining = new ArrayList<>(remaining);
     newRemaining.remove(0);
@@ -208,11 +208,13 @@ public final class PromptSession {
               + answers.size());
     }
 
-    var newAnswers = new ArrayList<>(answers);
-    var processed = new ArrayList<String>(newAnswers.size());
-    for (var raw : newAnswers) {
+    var newAnswers = new ArrayList<>(this.answers);
+    var processed = new ArrayList<String>(answers.size());
+    for (var raw : answers) {
+      Objects.requireNonNull(raw, "answers must not contain null elements");
       processed.add(current.sanitize() ? sanitize(raw) : raw);
     }
+    newAnswers.addAll(processed);
     var newRemaining = new ArrayList<>(remaining);
     newRemaining.remove(0);
 
@@ -231,7 +233,7 @@ public final class PromptSession {
     return new PromptSession(
         userId,
         parsedCommand,
-        Collections.unmodifiableList(processed),
+        Collections.unmodifiableList(newAnswers),
         Collections.unmodifiableList(newRemaining),
         pcmQueue,
         newState,
@@ -297,22 +299,35 @@ public final class PromptSession {
     return pcms.stream()
         .map(
             pcm -> {
-              var resolved = pcm.command();
-              for (int i = 0; i < answers.size(); i++) {
-                resolved = resolved.replace("{" + i + "}", answers.get(i));
+              // Match only against the original PCM template. appendReplacement prevents an answer
+              // containing "{1}" from being scanned again and substituted by a later answer.
+              var matcher = Pattern.compile("\\{(\\d+)}").matcher(pcm.command());
+              var resolved = new StringBuffer();
+              while (matcher.find()) {
+                int index;
+                try {
+                  index = Integer.parseInt(matcher.group(1));
+                } catch (NumberFormatException e) {
+                  index = -1;
+                }
+                String replacement = "";
+                if (index >= 0 && index < answers.size()) {
+                  replacement = answers.get(index);
+                } else {
+                  LOG.warning(
+                      "Unresolved PCM reference "
+                          + matcher.group()
+                          + " in command: "
+                          + pcm.command());
+                }
+                matcher.appendReplacement(
+                    resolved, java.util.regex.Matcher.quoteReplacement(replacement));
               }
-              var unresolved = Pattern.compile("\\{\\d+}").matcher(resolved);
-              if (unresolved.find()) {
-                LOG.warning(
-                    "Unresolved PCM reference "
-                        + unresolved.group()
-                        + " in command: "
-                        + pcm.command());
-                resolved = unresolved.replaceAll("");
-              }
-              resolved = resolved.replaceAll("\\s+", " ").trim();
+              matcher.appendTail(resolved);
+              var resolvedCommand = resolved.toString();
+              resolvedCommand = resolvedCommand.replaceAll("\\s+", " ").trim();
               return new PostCommandMeta(
-                  resolved,
+                  resolvedCommand,
                   pcm.answerIndices(),
                   pcm.delayTicks(),
                   pcm.onCancel(),

--- a/prompt-core/src/test/java/dev/cyr1en/promptcore/ParsedCommandTest.java
+++ b/prompt-core/src/test/java/dev/cyr1en/promptcore/ParsedCommandTest.java
@@ -1,5 +1,6 @@
 package dev.cyr1en.promptcore;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -155,5 +156,48 @@ class ParsedCommandTest {
     var partial = ParsedCommand.buildPartialCommand(parsed, List.of());
     assertEquals("/no_prompts no_tags_here ", partial);
     assertTrue(partial.length() > 0);
+  }
+
+  @Test
+  void duplicateRawTagsUseDistinctAnswers() {
+    var parsed = parser.parse("/say <a:value> <a:value>");
+
+    assertEquals(
+        "/say first second ",
+        ParsedCommand.buildPartialCommand(parsed, List.of("first", "second")));
+  }
+
+  @Test
+  void answerTextIsNotSearchedForAnotherPrompt() {
+    var parsed = parser.parse("/say <a:first> <a:second>");
+
+    assertEquals(
+        "/say <a:second> literal ",
+        ParsedCommand.buildPartialCommand(parsed, List.of("<a:second>", "literal")));
+  }
+
+  @Test
+  void parsedModelRetainsRawTemplateAndExactSpans() {
+    var parsed = parser.parse("/say <a:Why? \\>> <!log>");
+
+    assertEquals("/say <a:Why? \\>> <!log>", parsed.rawTemplateCommand());
+    assertEquals(2, parsed.templateSpans().size());
+    assertEquals("<a:Why? \\>>", parsed.templateSpans().get(0).rawText());
+    assertEquals("<!log>", parsed.templateSpans().get(1).rawText());
+  }
+
+  @Test
+  void postCommandArraysAreDefensivelyCopiedAndComparedByContent() {
+    var source = new int[] {1, 2};
+    var first = new PostCommandMeta("log", source, 0, false, DispatchTarget.PASSTHROUGH, false);
+    source[0] = 99;
+    var returned = first.answerIndices();
+    returned[1] = 99;
+
+    var second =
+        new PostCommandMeta("log", new int[] {1, 2}, 0, false, DispatchTarget.PASSTHROUGH, false);
+    assertArrayEquals(new int[] {1, 2}, first.answerIndices());
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
   }
 }

--- a/prompt-core/src/test/java/dev/cyr1en/promptcore/config/SnakeYamlDocumentTest.java
+++ b/prompt-core/src/test/java/dev/cyr1en/promptcore/config/SnakeYamlDocumentTest.java
@@ -1,0 +1,141 @@
+package dev.cyr1en.promptcore.config;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SnakeYamlDocumentTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void malformedYamlIsRejectedWithoutOverwritingTheFile() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    String original = "valid: [unterminated\n";
+    Files.writeString(file, original, StandardCharsets.UTF_8);
+
+    var failure =
+        assertThrows(ConfigurationException.class, () -> new SnakeYamlDocument(file.toFile()));
+
+    assertTrue(failure.getMessage().contains(file.toFile().getAbsolutePath()));
+    assertEquals(original, Files.readString(file, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void duplicateTopLevelKeyIsRejectedWithoutChangingTheSource() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    String original = "Prompt-Timeout: 10\nPrompt-Timeout: 20\n";
+    byte[] originalBytes = original.getBytes(StandardCharsets.UTF_8);
+    Files.write(file, originalBytes);
+
+    var failure =
+        assertThrows(ConfigurationException.class, () -> new SnakeYamlDocument(file.toFile()));
+
+    assertTrue(failure.getMessage().contains(file.toFile().getAbsolutePath()));
+    assertTrue(failure.getMessage().contains("Duplicate YAML key"));
+    assertArrayEquals(originalBytes, Files.readAllBytes(file));
+  }
+
+  @Test
+  void duplicateNestedKeyIsRejectedWithoutChangingTheSource() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    String original = "PlayerUI:\n  Size: 27\n  Size: 54\n";
+    byte[] originalBytes = original.getBytes(StandardCharsets.UTF_8);
+    Files.write(file, originalBytes);
+
+    var failure =
+        assertThrows(ConfigurationException.class, () -> new SnakeYamlDocument(file.toFile()));
+
+    assertTrue(failure.getMessage().contains(file.toFile().getAbsolutePath()));
+    assertTrue(failure.getMessage().contains("Duplicate YAML key"));
+    assertArrayEquals(originalBytes, Files.readAllBytes(file));
+  }
+
+  @Test
+  void scalarRootIsRejectedWithPath() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    Files.writeString(file, "just-a-scalar\n", StandardCharsets.UTF_8);
+
+    var failure =
+        assertThrows(ConfigurationException.class, () -> new SnakeYamlDocument(file.toFile()));
+
+    assertTrue(failure.getMessage().contains(file.toFile().getAbsolutePath()));
+    assertTrue(failure.getMessage().contains("mapping"));
+  }
+
+  @Test
+  void scalarParentCannotBeReplacedBySet() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    Files.writeString(file, "PlayerUI: disabled\n", StandardCharsets.UTF_8);
+    var document = new SnakeYamlDocument(file.toFile());
+
+    var failure =
+        assertThrows(
+            ConfigurationException.class, () -> document.set("PlayerUI.Size", 54, new String[0]));
+
+    assertTrue(failure.getMessage().contains("PlayerUI"));
+    assertTrue(failure.getMessage().contains("mapping"));
+    assertEquals("disabled", document.getString("PlayerUI"));
+  }
+
+  @Test
+  void conversionsRejectUnsafeValues() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    Files.writeString(
+        file,
+        "integer: 2147483648\nfraction: 1.5\nboolean: maybe\nnumber: .NaN\nitems: scalar\n",
+        StandardCharsets.UTF_8);
+    var document = new SnakeYamlDocument(file.toFile());
+
+    assertThrows(ConfigurationException.class, () -> document.getInt("integer"));
+    assertThrows(ConfigurationException.class, () -> document.getInt("fraction"));
+    assertThrows(ConfigurationException.class, () -> document.getBoolean("boolean"));
+    assertThrows(ConfigurationException.class, () -> document.getDouble("number"));
+    assertThrows(ConfigurationException.class, () -> document.getList("items"));
+  }
+
+  @Test
+  void saveCreatesAValidTargetAndListsAreNonNull() throws Exception {
+    Path file = tempDir.resolve("new.yml");
+    var document = new SnakeYamlDocument(file.toFile());
+    assertEquals(List.of(), document.getList("missing"));
+
+    document.set("values", List.of("one", "two"), new String[0]);
+    document.save(new String[] {"Header"});
+
+    assertTrue(Files.exists(file));
+    assertFalse(Files.readString(file, StandardCharsets.UTF_8).isBlank());
+    assertEquals(List.of("one", "two"), document.getList("values"));
+  }
+
+  @Test
+  void validConfigStillRoundTripsAndSaves() throws Exception {
+    Path file = tempDir.resolve("config.yml");
+    Files.writeString(
+        file,
+        "Prompt-Timeout: 15\nPlayerUI:\n  Size: 27\n  Enabled: true\n",
+        StandardCharsets.UTF_8);
+
+    var document = new SnakeYamlDocument(file.toFile());
+    assertEquals(15, document.getInt("Prompt-Timeout"));
+    assertEquals(27, document.getInt("PlayerUI.Size"));
+    assertTrue(document.getBoolean("PlayerUI.Enabled"));
+
+    document.set("PlayerUI.Enabled", false, new String[0]);
+    document.save(null);
+
+    var reloaded = new SnakeYamlDocument(file.toFile());
+    assertEquals(15, reloaded.getInt("Prompt-Timeout"));
+    assertEquals(27, reloaded.getInt("PlayerUI.Size"));
+    assertFalse(reloaded.getBoolean("PlayerUI.Enabled"));
+  }
+}

--- a/prompt-core/src/test/java/dev/cyr1en/promptcore/i18n/AbstractI18nTest.java
+++ b/prompt-core/src/test/java/dev/cyr1en/promptcore/i18n/AbstractI18nTest.java
@@ -1,0 +1,67 @@
+package dev.cyr1en.promptcore.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AbstractI18nTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void failedReloadRetainsThePublishedSnapshot() throws Exception {
+    var i18n =
+        new StringI18n(
+            "en_US",
+            tempDir.toFile(),
+            new ResourceClassLoader(Map.of("messages_en_US.properties", "hello=Hello\n")));
+    assertEquals("Hello", i18n.get("hello"));
+
+    Path locales = tempDir.resolve("locales");
+    Files.createDirectories(locales);
+    Files.writeString(
+        locales.resolve("messages_en_US.properties"), "bad=\\uZZZZ\n", StandardCharsets.UTF_8);
+
+    var failure = assertThrows(IllegalArgumentException.class, i18n::reload);
+
+    assertEquals("Hello", i18n.get("hello"));
+    assertEquals(true, failure.getMessage().contains("messages_en_US.properties"));
+  }
+
+  private static final class StringI18n extends AbstractI18n<String, Object> {
+    private StringI18n(String locale, java.io.File baseDir, ClassLoader loader) {
+      super(locale, baseDir, loader, Logger.getLogger("test-i18n"));
+    }
+
+    @Override
+    protected String postFormat(String text, Object context) {
+      return text;
+    }
+  }
+
+  private static final class ResourceClassLoader extends ClassLoader {
+    private final Map<String, String> resources;
+
+    private ResourceClassLoader(Map<String, String> resources) {
+      super(null);
+      this.resources = resources;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+      var value = resources.get(name);
+      return value == null
+          ? null
+          : new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/prompt-core/src/test/java/dev/cyr1en/promptcore/parser/CommandLineParserTest.java
+++ b/prompt-core/src/test/java/dev/cyr1en/promptcore/parser/CommandLineParserTest.java
@@ -3,6 +3,8 @@ package dev.cyr1en.promptcore.parser;
 import static org.junit.jupiter.api.Assertions.*;
 
 import dev.cyr1en.promptcore.*;
+import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -698,6 +700,48 @@ class CommandLineParserTest {
     var result = p.parse("/say <red>Hello</red> <a:Name?>");
     // Without a filter, <red>, </red>, and <a:Name?> are all treated as prompt tags.
     assertEquals(3, result.promptTags().size());
+  }
+
+  @Test
+  void pcmTargetRequiresBothTokenBoundaries() {
+    var result = parser.parse("/say <!hello@console>");
+    var pcm = result.postCmds().get(0);
+
+    assertEquals("hello@console", pcm.command());
+    assertEquals(DispatchTarget.PASSTHROUGH, pcm.dispatchTarget());
+  }
+
+  @Test
+  void flagsDoNotMatchDisplayTextSubstrings() {
+    var result = parser.parse("/say <a:cost-int cost-str cost-ds cost-iv:required>");
+    var tag = result.promptTags().get(0);
+
+    assertEquals(PromptTag.AnswerType.NONE, tag.type());
+    assertTrue(tag.sanitize());
+    assertNull(tag.validatorAlias());
+    assertEquals("cost-int cost-str cost-ds cost-iv:required", tag.displayText());
+  }
+
+  @Test
+  void parsedPcmSpansRemoveOnlyTheExactParsedTag() {
+    var filtered =
+        new CommandLineParser(ParserConfig.ANGLE_BRACKETS, content -> content.startsWith("!"));
+    var parsed = filtered.parse("/say \\<!kept> <!removed>");
+
+    assertTrue(parsed.postCmds().isEmpty());
+    assertEquals("/say <!kept> <!removed> ", ParsedCommand.buildPartialCommand(parsed, List.of()));
+  }
+
+  @Test
+  void unterminatedRepeatedOpenersAreScannedInLinearTime() {
+    var input = "<".repeat(200_000);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(2),
+        () -> {
+          assertFalse(parser.hasTagForm(input));
+          assertTrue(parser.parse(input).promptTags().isEmpty());
+        });
   }
 
   @Test

--- a/prompt-core/src/test/java/dev/cyr1en/promptcore/session/PromptSessionTest.java
+++ b/prompt-core/src/test/java/dev/cyr1en/promptcore/session/PromptSessionTest.java
@@ -154,6 +154,46 @@ class PromptSessionTest {
   }
 
   @Test
+  void compoundAnswersAppendToPriorHistoryAndResolveAllPCMReferences() {
+    var parsed =
+        parser.parse("/ban <a:Reason> <d:text:Name && d:num[0,24]:Days> <!audit {0} {1} {2}>");
+    var session = PromptSession.start("user1", parsed).submitAnswer("griefing");
+    var completed = session.submitAnswers(List.of("Steve", "7"));
+
+    assertEquals(List.of("griefing", "Steve", "7"), completed.answers());
+    assertEquals("/ban griefing Steve 7", completed.finish().assembledCommand());
+    assertEquals("audit griefing Steve 7", completed.finish().onCompleteCmds().get(0).command());
+  }
+
+  @Test
+  void pcmAnswerTextIsNotRescannedForLaterReferences() {
+    var parsed = parser.parse("/cmd <a:first -ds> <a:second> <!log {0} {1}>");
+    var completed =
+        PromptSession.start("user1", parsed).submitAnswer("{1}").submitAnswer("literal");
+
+    assertEquals("log {1} literal", completed.finish().onCompleteCmds().get(0).command());
+  }
+
+  @Test
+  void compoundAnswersRejectNullElementsBeforeSanitization() {
+    var parsed = parser.parse("/cmd <d:text:One && d:text:Two>");
+    var session = PromptSession.start("user1", parsed);
+    var answers = new java.util.ArrayList<String>();
+    answers.add("ok");
+    answers.add(null);
+
+    assertThrows(NullPointerException.class, () -> session.submitAnswers(answers));
+  }
+
+  @Test
+  void escapedDelimiterInsidePromptRemainsReplaceable() {
+    var parsed = parser.parse("/ask <a:Why? \\>>");
+    var completed = PromptSession.start("user1", parsed).submitAnswer("because");
+
+    assertEquals("/ask because", completed.finish().assembledCommand());
+  }
+
+  @Test
   void finish_cancelled_returnsOnCancelPCMs() {
     var parsed = parser.parse("/kick <a:Why?> <!! msg {0}>");
     var session = PromptSession.start("user1", parsed).cancel(CancelReason.MANUAL);

--- a/prompt-paper/build.gradle.kts
+++ b/prompt-paper/build.gradle.kts
@@ -1,10 +1,14 @@
 import java.net.HttpURLConnection
 import java.net.URI
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.util.Properties
+import java.util.jar.JarFile
 
 plugins {
     java
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("com.gradleup.shadow") version "9.6.1"
     `maven-publish`
 }
 
@@ -42,9 +46,9 @@ repositories {
 dependencies {
     implementation(project(":prompt-core"))
     implementation(project(":prompt-ui-api"))
-    compileOnly("io.papermc.paper:paper-api:26.1.2.build.+")
-    implementation("net.kyori:adventure-text-minimessage:4.26.1")
-    implementation("net.kyori:adventure-text-serializer-legacy:4.26.1")
+    compileOnly("io.papermc.paper:paper-api:26.1.2.build.74-stable")
+    compileOnly("net.kyori:adventure-text-minimessage:4.26.1")
+    compileOnly("net.kyori:adventure-text-serializer-legacy:4.26.1")
     implementation("org.bstats:bstats-bukkit:3.0.2")
     implementation("org.openjdk.nashorn:nashorn-core:15.4")
 
@@ -89,7 +93,16 @@ tasks.shadowJar {
     val nms26_2 = project(":prompt-ui-26.2").tasks.named("jar", Jar::class)
     from(nms26_2.map { zipTree(it.archiveFile) })
 
+    // Paper supplies Adventure. Keep those API/serializer classes out of the plugin jar and
+    // isolate bStats from other plugins that may ship a different bStats version.
+    relocate("org.bstats", "dev.cyr1en.promptpaper.libs.bstats")
     mergeServiceFiles()
+}
+
+// The shadow jar is the only distributable prompt-paper artifact. Keeping the ordinary Java jar
+// disabled prevents it from being mistaken for a release plugin by local tooling or CI uploads.
+tasks.named<Jar>("jar") {
+    enabled = false
 }
 
 tasks.build {
@@ -102,12 +115,11 @@ tasks.build {
 //
 // Tasks:
 //   - prepareServer : ensure <rootDir>/testserver/<version>/ exists with a
-//                     current Paper jar and accepted EULA. No start, no deploy.
-//   - stopServer    : kill the running paper process in the resolved root.
-//   - deploy        : prepareServer + stop + copy shadow jar + start.
+//                     current Paper jar and accepted EULA.
+//   - stopServer    : stop only the process recorded in the selected server root.
 //
 // Properties (all optional):
-//   -PpaperVersion=<v>   Minecraft version (e.g. 26.1.2, 1.21.11). Default: latest stable.
+//   -PpaperVersion=<v>   Paper version (e.g. 26.1.2, 26.2-rc-2). Default: latest stable.
 //   -PpaperBuild=<n>     Pin a specific build number. Default: latest matching -PpaperChannel.
 //   -PpaperChannel=<c>   stable | beta | alpha | default. Default: stable.
 //   -PtestServer=<path>  Override server root. Default: <rootDir>/testserver/<paperVersion>/.
@@ -116,9 +128,25 @@ tasks.build {
 //   (v2 /download endpoint is being sunset 2026-07-01 — already returns 404)
 
 val paperApiBase = "https://fill.papermc.io/v3/projects/paper"
-val paperJarPattern = Regex("""paper-([\d.]+)-(\d+)\.jar""")
+val paperJarPattern = Regex("""paper-(.+)-(\d+)\.jar""")
+val serverPidFileName = ".commandprompter-server.properties"
 
-data class PaperBuild(val id: Int, val channel: String, val downloadUrl: String, val jarName: String)
+data class PaperBuild(
+    val id: Int,
+    val channel: String,
+    val downloadUrl: String,
+    val jarName: String,
+    val sha256: String?
+)
+
+data class ExistingPaperJar(val file: File, val version: String, val build: Int)
+
+data class ServerProcessRecord(
+    val pid: Long,
+    val serverRoot: String,
+    val jar: String,
+    val startMillis: Long
+)
 
 fun httpGet(url: String): String {
     // nosemgrep
@@ -126,7 +154,7 @@ fun httpGet(url: String): String {
         requestMethod = "GET"
         connectTimeout = 15_000
         readTimeout = 60_000
-        setRequestProperty("User-Agent", "CommandPrompter-deploy/3.0")
+        setRequestProperty("User-Agent", "CommandPrompter-test-server/3.1")
     }
     return conn.inputStream.bufferedReader().use { it.readText() }
 }
@@ -215,7 +243,9 @@ fun resolveBuild(version: String, channelOrder: List<String>, pinned: Int? = nul
         val ch = chRe.find(obj)?.groupValues?.get(1) ?: return@mapNotNull null
         val url = urlRe.find(obj)?.groupValues?.get(1) ?: return@mapNotNull null
         val name = nameRe.find(obj)?.groupValues?.get(1) ?: return@mapNotNull null
-        PaperBuild(id, ch, url, name)
+        val sha256 = Regex(""""sha256"\s*:\s*"([0-9a-fA-F]{64})"""")
+            .find(obj)?.groupValues?.get(1)?.lowercase()
+        PaperBuild(id, ch, url, name, sha256)
     }
 
     if (pinned != null) {
@@ -228,28 +258,74 @@ fun resolveBuild(version: String, channelOrder: List<String>, pinned: Int? = nul
     return null
 }
 
-fun findExistingPaperJar(dir: File): Pair<String, Int>? {
+fun findExistingPaperJar(dir: File): ExistingPaperJar? {
     if (!dir.exists()) return null
-    val candidates = dir.listFiles { f -> paperJarPattern.matches(f.name) } ?: return null
-    val latest = candidates.maxByOrNull { it.lastModified() } ?: return null
+    val candidates = dir.listFiles { f -> f.isFile && paperJarPattern.matches(f.name) } ?: return null
+    val latest = candidates.maxWithOrNull(compareBy<File> { it.lastModified() }.thenBy { it.name })
+        ?: return null
     val match = paperJarPattern.matchEntire(latest.name) ?: return null
-    return match.groupValues[1] to match.groupValues[2].toInt()
+    return ExistingPaperJar(latest, match.groupValues[1], match.groupValues[2].toInt())
 }
 
-fun downloadFile(url: String, target: File) {
+fun sha256(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    Files.newInputStream(file.toPath()).use { input ->
+        val buffer = ByteArray(8192)
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            digest.update(buffer, 0, count)
+        }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+}
+
+fun isReadableJar(file: File): Boolean = try {
+    JarFile(file).use { true }
+} catch (e: Exception) {
+    false
+}
+
+fun downloadFile(url: String, target: File, expectedSha256: String?) {
     println("Downloading $url")
     println("         → $target")
     target.parentFile.mkdirs()
+    val temporary = Files.createTempFile(target.parentFile.toPath(), ".${target.name}.", ".part")
     // nosemgrep
     val conn = (URI.create(url).toURL().openConnection() as HttpURLConnection).apply {
         connectTimeout = 15_000
         readTimeout = 120_000
-        setRequestProperty("User-Agent", "CommandPrompter-deploy/3.0")
+        setRequestProperty("User-Agent", "CommandPrompter-test-server/3.1")
     }
-    conn.inputStream.use { input ->
-        Files.newOutputStream(target.toPath()).use { output ->
-            input.copyTo(output)
+    try {
+        if (conn.responseCode !in 200..299) {
+            error("Paper download failed with HTTP ${conn.responseCode}: $url")
         }
+        conn.inputStream.use { input ->
+            Files.newOutputStream(temporary).use { output ->
+                input.copyTo(output)
+            }
+        }
+        if (Files.size(temporary) <= 0L) error("Paper download produced an empty file: $url")
+        if (!isReadableJar(temporary.toFile())) error("Paper download is not a readable jar: $url")
+        if (expectedSha256 != null) {
+            val actual = sha256(temporary.toFile())
+            if (!actual.equals(expectedSha256, ignoreCase = true)) {
+                error("Paper checksum mismatch for $url: expected $expectedSha256, got $actual")
+            }
+        } else {
+            println("Paper API did not provide a SHA-256 checksum; accepting non-empty download.")
+        }
+        // Keep the temporary file beside the target and require an atomic replacement. A failed
+        // download therefore cannot leave a partial jar at the final path.
+        Files.move(
+            temporary,
+            target.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING)
+    } finally {
+        conn.disconnect()
+        Files.deleteIfExists(temporary)
     }
 }
 
@@ -263,44 +339,156 @@ fun resolveServerRoot(version: String): File {
     return if (override != null) file(override) else file("$rootDir/testserver/$version")
 }
 
-@Suppress("TooGenericExceptionCaught")
+fun resolveStopServerRoot(): File {
+    val override = project.findProperty("testServer") as? String
+    if (override != null) return file(override)
+
+    val configuredVersion = project.findProperty("paperVersion") as? String
+    if (configuredVersion != null) return file("$rootDir/testserver/$configuredVersion")
+
+    val base = file("$rootDir/testserver")
+    val tracked = base.listFiles { f ->
+        f.isDirectory && File(f, serverPidFileName).isFile
+    }?.toList() ?: emptyList()
+    if (tracked.size == 1) return tracked.single()
+    if (tracked.size > 1) {
+        error("Multiple tracked test servers exist; select one with -PtestServer=<directory>.")
+    }
+
+    // A server created before PID tracking cannot be stopped safely. Select a sole existing
+    // directory only to report that no tracked process is available; never scan or kill by name.
+    val existing = base.listFiles { f ->
+        f.isDirectory && (f.listFiles { jar -> jar.isFile && paperJarPattern.matches(jar.name) }?.isNotEmpty() == true)
+    }?.toList() ?: emptyList()
+    if (existing.size == 1) return existing.single()
+    if (existing.size > 1) {
+        error("Multiple test server directories exist; select one with -PtestServer=<directory>.")
+    }
+    return base
+}
+
+fun canonicalPath(file: File): String = file.canonicalFile.path
+
+fun readServerProcessRecord(serverRoot: File): ServerProcessRecord? {
+    val pidFile = File(serverRoot, serverPidFileName)
+    if (!pidFile.isFile) return null
+    return try {
+        val properties = Properties()
+        Files.newInputStream(pidFile.toPath()).use { properties.load(it) }
+        ServerProcessRecord(
+            properties.getProperty("pid").toLong(),
+            properties.getProperty("serverRoot"),
+            properties.getProperty("jar"),
+            properties.getProperty("startMillis").toLong())
+    } catch (e: Exception) {
+        println("Ignoring malformed server PID file $pidFile: ${e.message}")
+        null
+    }
+}
+
+fun writeServerProcessRecord(serverRoot: File, process: Process, jar: File) {
+    val handle = process.toHandle()
+    val properties = Properties()
+    properties["pid"] = handle.pid().toString()
+    properties["serverRoot"] = canonicalPath(serverRoot)
+    properties["jar"] = canonicalPath(jar)
+    properties["startMillis"] = handle.info().startInstant().map { it.toEpochMilli() }.orElse(0L).toString()
+
+    val temporary = Files.createTempFile(serverRoot.toPath(), ".commandprompter-server.", ".tmp")
+    try {
+        Files.newOutputStream(temporary).use { properties.store(it, "CommandPrompter test server process") }
+        Files.move(
+            temporary,
+            File(serverRoot, serverPidFileName).toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING)
+    } finally {
+        Files.deleteIfExists(temporary)
+    }
+}
+
+fun processMatches(handle: ProcessHandle, record: ServerProcessRecord, serverRoot: File): Boolean {
+    if (!handle.isAlive) return false
+    if (record.serverRoot != canonicalPath(serverRoot)) return false
+
+    val expectedJar = File(record.jar).canonicalFile
+    if (canonicalPath(expectedJar.parentFile) != canonicalPath(serverRoot)) return false
+
+    val info = handle.info()
+    val arguments = info.arguments().orElse(emptyArray<String>()).toList()
+    val jarArgument = arguments.indexOf("-jar").takeIf { it >= 0 }
+        ?.let { arguments.getOrNull(it + 1) }
+    val commandLine = info.commandLine().orElse("")
+    val jarMatches = jarArgument == expectedJar.path || commandLine.contains(expectedJar.path)
+    if (!jarMatches) return false
+
+    if (record.startMillis > 0L) {
+        val actualStart = info.startInstant().map { it.toEpochMilli() }.orElse(0L)
+        if (actualStart == 0L || actualStart != record.startMillis) return false
+    }
+    return true
+}
+
+fun waitForExit(handle: ProcessHandle, timeoutMillis: Long): Boolean {
+    val deadline = System.nanoTime() + timeoutMillis * 1_000_000L
+    while (handle.isAlive && System.nanoTime() < deadline) {
+        try {
+            Thread.sleep(100L)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return false
+        }
+    }
+    return !handle.isAlive
+}
+
+fun deleteServerProcessRecord(serverRoot: File, expected: ServerProcessRecord) {
+    if (readServerProcessRecord(serverRoot) == expected) {
+        Files.deleteIfExists(File(serverRoot, serverPidFileName).toPath())
+    }
+}
+
 fun stopServerIn(serverRoot: File) {
     if (!serverRoot.exists()) {
         println("Server root $serverRoot does not exist; nothing to stop.")
         return
     }
-    println("Stopping paper process (if any) in $serverRoot …")
-    
-    try {
-        // Use jps to safely find and kill the exact java process, avoiding pkill quirks on macOS
-        val jps = ProcessBuilder("jps", "-l").start()
-        val output = jps.inputStream.bufferedReader().readText()
-        jps.waitFor()
-        
-        output.lines().forEach { line ->
-            if (line.contains("paper-") && line.contains(".jar")) {
-                val pid = line.substringBefore(" ").trim()
-                println("Found running paper server (PID: $pid), killing...")
-                ProcessBuilder("kill", "-9", pid).start().waitFor()
-            }
-        }
-    } catch (e: java.io.IOException) {
-        println("jps kill method failed, falling back to pkill: ${e.message}")
-    } catch (e: InterruptedException) {
-        println("jps kill method failed, falling back to pkill: ${e.message}")
-    } catch (e: RuntimeException) {
-        println("jps kill method failed, falling back to pkill: ${e.message}")
+    val record = readServerProcessRecord(serverRoot)
+    if (record == null) {
+        println("No tracked server process in $serverRoot; refusing to search for other processes.")
+        return
     }
 
-    // Fallback: simple pkill without the complex regex that macOS often rejects
-    val proc = ProcessBuilder("bash", "-c", "pkill -9 -f 'paper-.*\\.jar' || true")
-        .directory(serverRoot)
-        .redirectErrorStream(true)
-        .start()
-    proc.inputStream.bufferedReader().use { print(it.readText()) }
-    proc.waitFor()
-    // Give the OS a moment to release file locks.
-    Thread.sleep(2000)
+    val handle = ProcessHandle.of(record.pid).orElse(null)
+    if (handle == null || !handle.isAlive) {
+        deleteServerProcessRecord(serverRoot, record)
+        println("Tracked server process ${record.pid} is no longer running.")
+        return
+    }
+    if (!processMatches(handle, record, serverRoot)) {
+        println("Refusing to stop PID ${record.pid}: it no longer matches $serverRoot/${File(record.jar).name}.")
+        return
+    }
+
+    println("Requesting graceful stop for Paper PID ${record.pid} in $serverRoot …")
+    handle.destroy()
+    if (!waitForExit(handle, 15_000L)) {
+        // Revalidate immediately before the forceful operation. Only the PID recorded for this
+        // exact root/jar may receive the forceful request; unrelated servers are never searched.
+        if (processMatches(handle, record, serverRoot)) {
+            println("Paper PID ${record.pid} did not stop gracefully; forcing that PID only.")
+            handle.destroyForcibly()
+            waitForExit(handle, 5_000L)
+        } else {
+            println("PID ${record.pid} changed before forceful stop; refusing to terminate it.")
+        }
+    }
+    if (!handle.isAlive) {
+        deleteServerProcessRecord(serverRoot, record)
+        println("Paper PID ${record.pid} stopped.")
+    } else {
+        println("Paper PID ${record.pid} is still running; PID file retained for a later stop.")
+    }
 }
 
 tasks.register("prepareServer") {
@@ -322,26 +510,31 @@ tasks.register("prepareServer") {
         println("Server root: $serverRoot")
 
         val existing = findExistingPaperJar(serverRoot)
-        val needsDownload = when {
-            existing == null -> true
-            existing.first != version -> true
-            existing.second < build.id -> true
-            else -> false
-        }
+        val existingIsValid = existing != null
+            && existing.version == version
+            && existing.build >= build.id
+            && existing.file.length() > 0L
+            && isReadableJar(existing.file)
+            && existing.file.name == build.jarName
+            && (build.sha256 == null || runCatching { sha256(existing.file) == build.sha256 }.getOrDefault(false))
+        val needsDownload = !existingIsValid
         if (needsDownload) {
-            existing?.let { (v, b) ->
-                if (v != version) {
-                    println("Existing jar is for a different version ($v); replacing.")
+            existing?.let { current ->
+                if (current.version != version) {
+                    println("Existing jar is for a different version (${current.version}); replacing.")
                 } else {
-                    println("Existing jar is build $b; upgrading to ${build.id}.")
+                    println("Existing jar is build ${current.build}; upgrading to ${build.id}.")
                 }
             } ?: println("No existing paper jar; downloading fresh.")
-            // Clear any old paper jars to keep the dir tidy.
-            serverRoot.listFiles { f -> paperJarPattern.matches(f.name) }?.forEach { it.delete() }
             val target = File(serverRoot, build.jarName)
-            downloadFile(build.downloadUrl, target)
+            downloadFile(build.downloadUrl, target, build.sha256)
+            // Remove superseded jars only after the new jar has been downloaded, checked, and
+            // atomically installed.
+            serverRoot.listFiles { f ->
+                f.isFile && paperJarPattern.matches(f.name) && canonicalPath(f) != canonicalPath(target)
+            }?.forEach { it.delete() }
         } else {
-            println("Existing jar ${existing!!.first} build ${existing.second} is up to date.")
+            println("Existing jar ${existing!!.file.name} build ${existing.build} is up to date.")
         }
 
         val eula = File(serverRoot, "eula.txt")
@@ -356,12 +549,11 @@ tasks.register("prepareServer") {
 
 tasks.register("stopServer") {
     description = "Stop the running Paper test server. " +
-        "Uses -PtestServer if set, otherwise <rootDir>/testserver/<paperVersion>/."
+        "Uses -PtestServer, -PpaperVersion, or the sole existing tracked server directory."
     group = "commandprompter"
 
     doLast {
-        val version = resolveVersionProperty()
-        stopServerIn(resolveServerRoot(version))
+        stopServerIn(resolveStopServerRoot())
         println("Server stopped.")
     }
 }
@@ -410,13 +602,45 @@ tasks.register("startServer") {
         val jar = (serverRoot.listFiles { f -> paperJarPattern.matches(f.name) } ?: emptyArray())
             .maxByOrNull { it.lastModified() }
             ?: error("No paper-*.jar in $serverRoot — did prepareServer run?")
-        println("Starting $jar in $serverRoot …")
-        
-        val process = ProcessBuilder("java", "-jar", jar.name, "-nogui")
+        val existingRecord = readServerProcessRecord(serverRoot)
+        if (existingRecord != null) {
+            val existingHandle = ProcessHandle.of(existingRecord.pid).orElse(null)
+            if (existingHandle != null && existingHandle.isAlive) {
+                if (processMatches(existingHandle, existingRecord, serverRoot)) {
+                    error("Paper test server is already running with PID ${existingRecord.pid}.")
+                }
+                error("PID file ${File(serverRoot, serverPidFileName)} points to an unrelated process; refusing to overwrite it.")
+            }
+            deleteServerProcessRecord(serverRoot, existingRecord)
+        }
+
+        val javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(25)
+        }.get().executablePath.asFile
+        println("Starting $jar in $serverRoot with Java 25 launcher $javaLauncher …")
+
+        val process = ProcessBuilder(javaLauncher.absolutePath, "-jar", jar.absolutePath, "-nogui")
             .directory(serverRoot)
             .inheritIO()
             .start()
-            
-        process.waitFor()
+        try {
+            writeServerProcessRecord(serverRoot, process, jar)
+        } catch (e: Exception) {
+            process.destroyForcibly()
+            throw e
+        }
+
+        try {
+            process.waitFor()
+        } finally {
+            if (!process.isAlive) {
+                val record = readServerProcessRecord(serverRoot)
+                if (record != null && record.pid == process.pid()) {
+                    deleteServerProcessRecord(serverRoot, record)
+                }
+            } else {
+                println("Paper PID ${process.pid()} is still running; retaining $serverPidFileName.")
+            }
+        }
     }
 }

--- a/prompt-paper/build.gradle.kts
+++ b/prompt-paper/build.gradle.kts
@@ -5,6 +5,7 @@ import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.Properties
 import java.util.jar.JarFile
+import org.gradle.api.file.DuplicatesStrategy
 
 plugins {
     java
@@ -84,14 +85,20 @@ tasks.shadowJar {
     archiveBaseName.set("CommandPrompterPaper")
     archiveClassifier.set("")
     archiveVersion.set(project.version.toString())
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
     dependsOn(":prompt-ui-26.1:jar", ":prompt-ui-26.2:jar")
+    val screenProviderService = "META-INF/services/dev.cyr1en.promptui.ScreenProvider"
     // MUST use zipTree — avoids Java 25 NMS classes on Java 21 API classpath
     val nms26_1 = project(":prompt-ui-26.1").tasks.named("jar", Jar::class)
-    from(nms26_1.map { zipTree(it.archiveFile) })
+    from(nms26_1.map { zipTree(it.archiveFile) }) {
+        exclude(screenProviderService)
+    }
     
     val nms26_2 = project(":prompt-ui-26.2").tasks.named("jar", Jar::class)
-    from(nms26_2.map { zipTree(it.archiveFile) })
+    from(nms26_2.map { zipTree(it.archiveFile) }) {
+        exclude(screenProviderService)
+    }
 
     // Paper supplies Adventure. Keep those API/serializer classes out of the plugin jar and
     // isolate bStats from other plugins that may ship a different bStats version.

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompter.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompter.java
@@ -19,6 +19,7 @@ import dev.cyr1en.promptpaper.util.PluginLogger;
 import dev.cyr1en.promptpaper.util.Scheduler;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -170,6 +171,9 @@ public class CommandPrompter extends JavaPlugin implements Listener {
         }
         if (hookContainer != null) hookContainer.disableAll();
         if (engine != null) engine.cancelAll();
+        if (screenManager != null) {
+            Bukkit.getOnlinePlayers().forEach(screenManager::cancelAll);
+        }
         if (pluginLogger != null) {
             pluginLogger.info("CommandPrompterPaper disabled.");
         }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompter.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompter.java
@@ -18,6 +18,7 @@ import dev.cyr1en.promptpaper.util.PaperScheduler;
 import dev.cyr1en.promptpaper.util.PluginLogger;
 import dev.cyr1en.promptpaper.util.Scheduler;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.event.player.AsyncChatEvent;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -148,7 +149,13 @@ public class CommandPrompter extends JavaPlugin implements Listener {
             }
         }
         var listener = new ChatPromptListener(this, screenManager);
-        getServer().getPluginManager().registerEvents(listener, this);
+        getServer().getPluginManager().registerEvent(
+                AsyncChatEvent.class,
+                listener,
+                listener.resolvePriority(),
+                (registeredListener, event) -> listener.onPlayerChat((AsyncChatEvent) event),
+                this,
+                false);
         pluginLogger.info("Using default Bukkit chat listener");
     }
 
@@ -172,7 +179,18 @@ public class CommandPrompter extends JavaPlugin implements Listener {
         if (hookContainer != null) hookContainer.disableAll();
         if (engine != null) engine.cancelAll();
         if (screenManager != null) {
-            Bukkit.getOnlinePlayers().forEach(screenManager::cancelAll);
+            for (var player : Bukkit.getOnlinePlayers()) {
+                var uuid = player.getUniqueId();
+                try {
+                    var task = player.getScheduler().run(
+                            this,
+                            scheduledTask -> screenManager.cancelAll(player),
+                            () -> screenManager.discardState(uuid));
+                    if (task == null) screenManager.discardState(uuid);
+                } catch (Throwable t) {
+                    screenManager.discardState(uuid);
+                }
+            }
         }
         if (pluginLogger != null) {
             pluginLogger.info("CommandPrompterPaper disabled.");

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompterBootstrap.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/CommandPrompterBootstrap.java
@@ -8,22 +8,18 @@ import org.bukkit.plugin.java.JavaPlugin;
 /**
  * Paper plugin bootstrap executed before {@link CommandPrompter} is loaded.
  * <p>
- * Disables the bStats relocation check. This property must be set in
- * {@code bootstrap()} — before the shaded bStats library inspects its own
- * class locations — and cannot be moved to {@link CommandPrompter#onEnable()}.
- * <p>
+ * The bootstrap is intentionally limited to creating the plugin instance.
  * Command registration is handled in {@link CommandPrompter#onEnable()} via
- * {@code LifecycleEvents.COMMANDS}. Registering the handler here was tried
- * first but proven unreliable: Paper can fire the COMMANDS event before
- * {@link #createPlugin(PluginProviderContext)} populates the bootstrap's
- * plugin reference, leaving a null at registration time and producing an
- * NPE on the first command invocation.
+ * {@code LifecycleEvents.COMMANDS}; registering the handler here can happen
+ * before the plugin instance is available to command constructors. bStats is
+ * relocated in the shadow jar, so no global relocation-check override is
+ * required here.
  */
 public class CommandPrompterBootstrap implements PluginBootstrap {
 
     @Override
     public void bootstrap(BootstrapContext context) {
-        System.setProperty("bstats.relocatecheck", "false");
+        // Keep bootstrap side-effect free. Shaded libraries are privately relocated.
     }
 
     @Override

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CancelCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CancelCommand.java
@@ -4,7 +4,6 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import dev.cyr1en.promptcore.CancelReason;
 import dev.cyr1en.promptpaper.CommandPrompter;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
@@ -53,7 +52,7 @@ public class CancelCommand extends PromptCommand implements Command<CommandSourc
             player.sendMessage(i18n.get("command.cancel.no_active_prompt"));
             return;
         }
-        plugin.getEngine().cancel(player, CancelReason.MANUAL);
+        plugin.getScreenManager().cancelAll(player);
         player.sendMessage(i18n.get("prompt.cancelled"));
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CancelCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CancelCommand.java
@@ -53,6 +53,8 @@ public class CancelCommand extends PromptCommand implements Command<CommandSourc
             return;
         }
         plugin.getScreenManager().cancelAll(player);
-        player.sendMessage(i18n.get("prompt.cancelled"));
+        if (plugin.getConfigLoader().getConfig().showCancelled()) {
+            player.sendMessage(i18n.get("prompt.cancelled"));
+        }
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CommandRegistrar.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/CommandRegistrar.java
@@ -13,8 +13,8 @@ import java.util.List;
  * pointer via constructor injection.
  *
  * <p>The lifecycle handler that drives this is registered in
- * {@link CommandPrompterBootstrap#bootstrap}. When Paper fires
- * {@code LifecycleEvents.COMMANDS}, the bootstrap constructs a new
+ * {@link CommandPrompter#onEnable()}. When Paper fires
+ * {@code LifecycleEvents.COMMANDS}, the plugin constructs a new
  * {@code CommandRegistrar(plugin)} and calls
  * {@link #registerAll(Commands)} on the event's registrar.
  */

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ConsoleDelegateCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ConsoleDelegateCommand.java
@@ -11,6 +11,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import net.kyori.adventure.text.Component;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
@@ -20,9 +21,9 @@ import static io.papermc.paper.command.brigadier.Commands.argument;
 
 /**
  * {@code /consoledelegate <target> <command>} — runs a prompted command on
- * behalf of the named target player, but the dispatcher is the console. The
- * {@code %target_player%} placeholder in the command string is replaced
- * with the target player's name before the session is started.
+ * behalf of each resolved target player, but the dispatcher is the console.
+ * The {@code %target_player%} placeholder is resolved on the target's region
+ * thread before the session is started.
  *
  * <p>Restricted to console senders with {@code promptpaper.consoledelegate}.
  * The target is parsed via {@link ArgumentTypes#player()} which gives us
@@ -50,9 +51,16 @@ public class ConsoleDelegateCommand extends PromptCommand implements Command<Com
     @Override
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         var resolver = context.getArgument("target", PlayerSelectorArgumentResolver.class);
-        var target = resolver.resolve(context.getSource()).getFirst();
+        var targets = resolver.resolve(context.getSource());
+        var sender = context.getSource().getSender();
+        if (targets == null || targets.isEmpty()) {
+            sender.sendMessage(Component.text("No players matched the selector."));
+            return 0;
+        }
         var command = StringArgumentType.getString(context, "command");
-        startSession(context.getSource().getSender().getName(), target, command);
+        for (var target : targets) {
+            startSession(sender.getName(), target, command);
+        }
         return Command.SINGLE_SUCCESS;
     }
 
@@ -61,26 +69,13 @@ public class ConsoleDelegateCommand extends PromptCommand implements Command<Com
      * Brigadier executor so it can be unit-tested without constructing a
      * {@link CommandContext}.
      *
-     * <p>Normalization: a leading {@code /} is stripped (Bukkit would
-     * strip it on dispatch anyway, but keeping the slash out of session
-     * state keeps logs and parsed-template output consistent), and
-     * {@code %target_player%} is replaced with the target player's name.
+     * <p>Normalization: a leading {@code /} is stripped. Target-dependent
+     * normalization is completed by {@link ScreenManager} on the target's
+     * region thread.
      */
     public void startSession(String senderName, Player target, String command) {
-        if (plugin.getEngine().hasActiveSession(target)) {
-            plugin.getPluginLogger().warn("Cannot delegate prompt to " + target.getName() + " because they are already in an active prompt session.");
-            return;
-        }
-        if (command.startsWith("/")) {
-            command = command.substring(1);
-        }
-        if (command.contains("%target_player%")) {
-            command = command.replace("%target_player%", target.getName());
-        }
-        plugin.getPluginLogger().info(senderName
-                + " used /consoledelegate -> " + target.getName() + ": " + command);
-        plugin.getPluginLogger().debug("ConsoleDelegate: target=" + target.getName()
-                + " uuid=" + target.getUniqueId() + " mode=CONSOLE");
+        if (command.startsWith("/")) command = command.substring(1);
+        plugin.getPluginLogger().info(senderName + " used /consoledelegate: " + command);
         plugin.getScreenManager().startDelegatedSession(target, command,
                 ScreenManager.DispatchMode.CONSOLE, null);
     }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/PlayerDelegateCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/PlayerDelegateCommand.java
@@ -12,6 +12,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
+import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
@@ -24,8 +25,8 @@ import static io.papermc.paper.command.brigadier.Commands.argument;
  * {@code /playerdelegate <target> <permissionKey> <command>} — starts a
  * prompted command session as the target player with a temporary permission
  * attachment resolved from {@code permissionKey} in the plugin config. The
- * {@code %target_player%} placeholder in the command string is replaced
- * with the target player's name.
+ * {@code %target_player%} placeholder is resolved on the target's region
+ * thread.
  *
  * <p>Restricted to console senders with {@code promptpaper.playerdelegate}.
  * The {@code permissionKey} argument is tab-completed from the configured
@@ -60,10 +61,18 @@ public class PlayerDelegateCommand extends PromptCommand implements Command<Comm
     @Override
     public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         var resolver = context.getArgument("target", PlayerSelectorArgumentResolver.class);
-        var target = resolver.resolve(context.getSource()).getFirst();
+        var targets = resolver.resolve(context.getSource());
+        var sender = context.getSource().getSender();
+        if (targets == null || targets.isEmpty()) {
+            sender.sendMessage(Component.text("No players matched the selector."));
+            return 0;
+        }
         var permKey = StringArgumentType.getString(context, "permissionKey");
         var command = StringArgumentType.getString(context, "command");
-        return executeDispatch(context.getSource().getSender(), target, permKey, command);
+        for (var target : targets) {
+            executeDispatch(sender, target, permKey, command);
+        }
+        return Command.SINGLE_SUCCESS;
     }
 
     /**
@@ -73,19 +82,12 @@ public class PlayerDelegateCommand extends PromptCommand implements Command<Comm
      * the unknown-permission-key error path.
      */
     public int executeDispatch(CommandSender sender, Player target, String permKey, String command) {
-        if (plugin.getEngine().hasActiveSession(target)) {
-            plugin.getPluginLogger().warn("Cannot delegate prompt to " + target.getName() + " because they are already in an active prompt session.");
-            return Command.SINGLE_SUCCESS;
-        }
-        if (command.startsWith("/")) {
-            command = command.substring(1);
-        }
-        if (command.contains("%target_player%")) {
-            command = command.replace("%target_player%", target.getName());
-        }
+        if (command.startsWith("/")) command = command.substring(1);
         var config = plugin.getConfigLoader().getConfig();
-        var perms = config.getPermissionAttachment(permKey);
-        if (perms.length == 0) {
+        var perms = config == null || permKey == null || permKey.isBlank()
+                ? null
+                : config.getPermissionAttachment(permKey);
+        if (perms == null || perms.length == 0) {
             var senderPlayer = sender instanceof Player p ? p : null;
             sender.sendMessage(plugin.getConfigLoader().getI18n().get(
                     "command.delegate.unknown_permission",
@@ -94,12 +96,7 @@ public class PlayerDelegateCommand extends PromptCommand implements Command<Comm
             return Command.SINGLE_SUCCESS;
         }
         plugin.getPluginLogger().info(sender.getName()
-                + " used /playerdelegate -> " + target.getName()
-                + " permKey=" + permKey + ": " + command);
-        plugin.getPluginLogger().debug("PlayerDelegate: target=" + target.getName()
-                + " uuid=" + target.getUniqueId()
-                + " permKey=" + permKey + " perms=" + perms.length
-                + " mode=ATTACHMENT");
+                + " used /playerdelegate permKey=" + permKey + ": " + command);
         plugin.getScreenManager().startDelegatedSession(target, command,
                 ScreenManager.DispatchMode.ATTACHMENT, permKey);
         return Command.SINGLE_SUCCESS;

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/PromptCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/PromptCommand.java
@@ -26,6 +26,9 @@ import java.util.List;
  */
 public abstract class PromptCommand {
 
+    /** Master permission granted by Paper to all CommandPrompter commands. */
+    private static final String ADMIN_PERMISSION = "promptpaper.admin";
+
     private final String name;
     private final String description;
     private final List<String> aliases;
@@ -61,11 +64,15 @@ public abstract class PromptCommand {
 
     /**
      * Returns true if the given sender may use this command. Combines the
-     * optional {@code permission} and {@code senderFilter} into a single
-     * predicate. Either check being absent is treated as a pass.
+     * optional {@code permission}, master admin permission, and sender filter
+     * into a single predicate. An explicit command permission remains valid on
+     * its own; {@code promptpaper.admin} is an override for every command.
      */
     public final boolean allowed(CommandSender sender) {
-        if (permission != null && !sender.hasPermission(permission)) {
+        if (sender == null) return false;
+        if (permission != null
+                && !sender.hasPermission(permission)
+                && !sender.hasPermission(ADMIN_PERMISSION)) {
             return false;
         }
         if (senderFilter != null && !senderFilter.isInstance(sender)) {

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ReloadCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ReloadCommand.java
@@ -6,11 +6,21 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.cyr1en.promptcore.i18n.Placeholder;
 import dev.cyr1en.promptpaper.CommandPrompter;
+import dev.cyr1en.promptpaper.engine.PromptEngine;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@code /commandprompter reload} — cancels every active session across
@@ -46,16 +56,98 @@ public class ReloadCommand extends PromptCommand implements Command<CommandSourc
      * directly with a mock {@link CommandSender}.
      */
     public void executeReload(CommandSender sender) {
-        plugin.getPluginLogger().info("Configuration reloaded by " + sender.getName());
-        // Cancel active sessions to prevent references to outdated config values.
+        plugin.getPluginLogger().info("Reload requested by " + sender.getName());
         plugin.getPluginLogger().debug("Reload: cancelling all active sessions before config reload");
-        if (plugin.getScreenManager() != null && plugin.getEngine() != null) {
-            for (var player : plugin.getServer().getOnlinePlayers()) {
-                plugin.getScreenManager().cancelAll(player);
+        var feedbackLocation = captureBlockLocation(sender);
+        var gateOwner = plugin.getEngine();
+        if (gateOwner != null) {
+            boolean acquired;
+            try {
+                acquired = gateOwner.beginReload();
+            } catch (Exception e) {
+                plugin.getPluginLogger().err("Unable to acquire reload barrier: " + e.getMessage());
+                sendResult(sender, feedbackLocation, reloadFailure(e.getMessage()));
+                return;
             }
-            plugin.getEngine().cancelAll();
+            if (!acquired) {
+                plugin.getPluginLogger().debug("Reload already in progress; rejecting reload request");
+                sendResult(sender, feedbackLocation, reloadFailure("another reload is already in progress"));
+                return;
+            }
         }
+        ArrayList<Player> players;
         try {
+            players = new ArrayList<>(plugin.getServer().getOnlinePlayers());
+        } catch (Throwable t) {
+            plugin.getPluginLogger().err("Unable to enumerate players for reload: " + t.getMessage());
+            try {
+                sendResult(sender, feedbackLocation, reloadFailure(t.getMessage()));
+            } finally {
+                releaseReloadGate(gateOwner);
+            }
+            return;
+        }
+        if (plugin.getScreenManager() == null || plugin.getEngine() == null || players.isEmpty()) {
+            scheduleReload(sender, feedbackLocation, gateOwner);
+            return;
+        }
+
+        var remaining = new AtomicInteger(players.size());
+        var reloadScheduled = new AtomicBoolean();
+        for (var player : players) {
+            var uuid = player.getUniqueId();
+            var completed = new AtomicBoolean();
+            Runnable finish = () -> {
+                if (completed.compareAndSet(false, true)
+                        && remaining.decrementAndGet() == 0
+                        && reloadScheduled.compareAndSet(false, true)) {
+                    scheduleReload(sender, feedbackLocation, gateOwner);
+                }
+            };
+            try {
+                var task = player.getScheduler().run(
+                        plugin,
+                        scheduledTask -> {
+                            try {
+                                plugin.getScreenManager().cancelAll(player);
+                            } finally {
+                                finish.run();
+                            }
+                        },
+                        () -> discardPlayerState(uuid, finish));
+                if (task == null) {
+                    discardPlayerState(uuid, finish);
+                }
+            } catch (Throwable t) {
+                plugin.getPluginLogger().debug(
+                        "Player teardown scheduling failed for " + uuid + ": " + t.getMessage());
+                discardPlayerState(uuid, finish);
+            }
+        }
+    }
+
+    private void scheduleReload(
+            CommandSender sender, Location feedbackLocation, PromptEngine gateOwner) {
+        try {
+            plugin.getScheduler().runSync(
+                    () -> reloadAfterTeardown(sender, feedbackLocation, gateOwner));
+        } catch (Throwable t) {
+            plugin.getPluginLogger().err("Unable to schedule configuration reload: " + t.getMessage());
+            try {
+                sendResult(sender, feedbackLocation, plugin.getConfigLoader().getI18n().get(
+                        "command.reload.failed",
+                        Placeholder.of("error", t.getMessage() != null ? t.getMessage() : "")));
+            } finally {
+                releaseReloadGate(gateOwner);
+            }
+        }
+    }
+
+    private void reloadAfterTeardown(
+            CommandSender sender, Location feedbackLocation, PromptEngine gateOwner) {
+        try {
+            if (plugin.getEngine() != null)
+                plugin.getEngine().discardAll();
             plugin.getConfigLoader().reload();
             var loader = plugin.getConfigLoader();
             var cfg = loader.getConfig();
@@ -73,13 +165,97 @@ public class ReloadCommand extends PromptCommand implements Command<CommandSourc
                         registry.postCommandCount() + " post commands</gold>";
                 plugin.getPluginLogger().info(presetMsg);
                 plugin.getPluginLogger().debug("Loaded prompt IDs: " + String.join(", ", registry.getPromptIds()));
-                plugin.getPluginLogger().debug("Loaded post-command IDs: " + String.join(", ", registry.getPostCommandIds()));
+                plugin.getPluginLogger()
+                        .debug("Loaded post-command IDs: " + String.join(", ", registry.getPostCommandIds()));
             }
-            sender.sendMessage(plugin.getConfigLoader().getI18n().get("command.reload.success"));
+            sendResult(sender, feedbackLocation,
+                    plugin.getConfigLoader().getI18n().get("command.reload.success"));
         } catch (Exception e) {
-            sender.sendMessage(plugin.getConfigLoader().getI18n().get(
+            sendResult(sender, feedbackLocation, plugin.getConfigLoader().getI18n().get(
                     "command.reload.failed",
                     Placeholder.of("error", e.getMessage() != null ? e.getMessage() : "")));
+        } finally {
+            releaseReloadGate(gateOwner);
+        }
+    }
+
+    void sendResult(CommandSender sender, Location feedbackLocation, Component message) {
+        if (sender instanceof Player player) {
+            try {
+                var task = player.getScheduler().run(
+                        plugin, scheduledTask -> player.sendMessage(message), () -> {
+                        });
+                if (task == null) {
+                    plugin.getPluginLogger().debug("Reload result sender retired; omitting feedback");
+                }
+            } catch (Exception e) {
+                plugin.getPluginLogger().debug("Reload result sender retired: " + e.getMessage());
+            }
+            return;
+        }
+
+        if (sender instanceof BlockCommandSender blockSender) {
+            if (feedbackLocation == null) {
+                plugin.getPluginLogger().debug(
+                        "Unable to route reload result: block sender has no captured location");
+                return;
+            }
+            try {
+                Bukkit.getRegionScheduler().run(
+                        plugin,
+                        feedbackLocation,
+                        scheduledTask -> blockSender.sendMessage(message));
+            } catch (Exception e) {
+                plugin.getPluginLogger().debug(
+                        "Unable to route reload result to block sender: " + e.getMessage());
+            }
+            return;
+        }
+
+        try {
+            // PaperScheduler maps runSync to the global-region scheduler.
+            plugin.getScheduler().runSync(() -> sender.sendMessage(message));
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to send reload result: " + e.getMessage());
+        }
+    }
+
+    private Location captureBlockLocation(CommandSender sender) {
+        if (!(sender instanceof BlockCommandSender blockSender))
+            return null;
+        try {
+            return blockSender.getBlock().getLocation().clone();
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to capture block sender location: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Component reloadFailure(String detail) {
+        return plugin.getConfigLoader().getI18n().get(
+                "command.reload.failed",
+                Placeholder.of("error", detail != null ? detail : ""));
+    }
+
+    private void releaseReloadGate(PromptEngine gateOwner) {
+        if (gateOwner == null)
+            return;
+        try {
+            gateOwner.endReload();
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to release reload barrier: " + e.getMessage());
+        }
+    }
+
+    private void discardPlayerState(UUID uuid, Runnable finish) {
+        try {
+            plugin.getScreenManager().discardState(uuid);
+            plugin.getEngine().discard(uuid);
+        } catch (Throwable t) {
+            plugin.getPluginLogger().debug(
+                    "Unable to discard player state for " + uuid + ": " + t.getMessage());
+        } finally {
+            finish.run();
         }
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ReloadCommand.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/command/ReloadCommand.java
@@ -109,7 +109,7 @@ public class ReloadCommand extends PromptCommand implements Command<CommandSourc
                         plugin,
                         scheduledTask -> {
                             try {
-                                plugin.getScreenManager().cancelAll(player);
+                                plugin.getScreenManager().cancelAll(player, true);
                             } finally {
                                 finish.run();
                             }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/PaperConfigLoader.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/PaperConfigLoader.java
@@ -13,9 +13,7 @@ public class PaperConfigLoader {
 
     private final CommandPrompter plugin;
     private final RecordConfigLoader configManager;
-    private CommandPrompterConfig config;
-    private PromptConfig promptConfig;
-    private PaperI18n i18n;
+    private volatile ConfigState state;
 
     /**
      * Creates the loader and immediately loads all config files.
@@ -30,35 +28,38 @@ public class PaperConfigLoader {
 
     /** Re-reads {@code config.yml} and {@code prompt-config.yml} from disk, replacing all cached records. */
     public void reload() {
-        config = configManager.getConfig(CommandPrompterConfig.class);
-        plugin.getLogger().fine("config.yml loaded: timeout=" + config.promptTimeout()
-                + " debug=" + config.debugMode() + " fancy=" + config.fancyLogger()
-                + " locale=" + config.locale());
-        promptConfig = configManager.getConfig(PromptConfig.class);
+        // Load and validate the complete replacement off to the side. A single volatile state
+        // publication prevents player scheduler threads from observing a mixed old/new set.
+        var newConfig = configManager.getConfig(CommandPrompterConfig.class);
+        plugin.getLogger().fine("config.yml loaded: timeout=" + newConfig.promptTimeout()
+                + " debug=" + newConfig.debugMode() + " fancy=" + newConfig.fancyLogger()
+                + " locale=" + newConfig.locale());
+        var newPromptConfig = configManager.getConfig(PromptConfig.class);
         plugin.getLogger().fine("prompt-config.yml loaded: mappings="
-                + promptConfig.getScreenMappings().size());
-        if (i18n == null || !i18n.getLocale().equals(config.locale())) {
-            i18n = new PaperI18n(
-                    config.locale(),
-                    plugin.getDataFolder(),
-                    plugin.getClass().getClassLoader(),
-                    plugin.getLogger());
-        } else {
-            i18n.reload();
-        }
-        plugin.getLogger().fine("i18n reloaded for locale=" + config.locale());
+                + newPromptConfig.getScreenMappings().size());
+        var newI18n = new PaperI18n(
+                newConfig.locale(),
+                plugin.getDataFolder(),
+                plugin.getClass().getClassLoader(),
+                plugin.getLogger());
+        plugin.getLogger().fine("i18n reloaded for locale=" + newConfig.locale());
+        var newState = new ConfigState(newConfig, newPromptConfig, newI18n);
+        state = newState;
         plugin.getLogger().fine("Configuration reloaded successfully");
     }
 
     public CommandPrompterConfig getConfig() {
-        return config;
+        return state.config();
     }
 
     public PromptConfig getPromptConfig() {
-        return promptConfig;
+        return state.promptConfig();
     }
 
     public PaperI18n getI18n() {
-        return i18n;
+        return state.i18n();
     }
+
+    private record ConfigState(
+            CommandPrompterConfig config, PromptConfig promptConfig, PaperI18n i18n) {}
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/PromptConfig.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/PromptConfig.java
@@ -13,6 +13,8 @@ import dev.cyr1en.promptpaper.validation.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.bukkit.entity.Player;
 
@@ -472,6 +474,58 @@ public record PromptConfig(
         int dialogTabMaxButtons
 
 ) implements AliasedSection {
+
+    /** Validate values that are consumed by UI builders before a new config can be published. */
+    public PromptConfig {
+        Objects.requireNonNull(rawConfig, "rawConfig");
+        if (playerUISize != 18 && playerUISize != 27 && playerUISize != 36
+                && playerUISize != 45 && playerUISize != 54) {
+            throw new IllegalArgumentException(
+                    "PlayerUI.Size must be one of 18, 27, 36, 45, or 54; got " + playerUISize);
+        }
+        if (!Float.isFinite(dialogNumberMin)
+                || !Float.isFinite(dialogNumberMax)
+                || !Float.isFinite(dialogNumberStep)
+                || dialogNumberMin >= dialogNumberMax
+                || dialogNumberStep <= 0.0f
+                || !Float.isFinite((dialogNumberMin + dialogNumberMax) / 2.0f)) {
+            throw new IllegalArgumentException(
+                    "DialogUI.Defaults.Number must have finite values with min < max and step > 0"
+                            + " (min=" + dialogNumberMin
+                            + ", max=" + dialogNumberMax
+                            + ", step=" + dialogNumberStep + ")");
+        }
+        validateRegex("Input-Validation.Integer-Sample.Regex", intSampleRegex);
+        validateRegex("Input-Validation.Alpha-Sample.Regex", strSampleRegex);
+        validateConfiguredRegexes(rawConfig);
+    }
+
+    private static void validateRegex(String path, String regex) {
+        if (regex == null) {
+            throw new IllegalArgumentException("Configured validator regex '" + path + "' must not be null");
+        }
+        try {
+            Pattern.compile(regex);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                    "Invalid configured validator regex at '" + path + "': " + regex, e);
+        }
+    }
+
+    private static void validateConfiguredRegexes(YamlDocument rawConfig) {
+        Set<String> aliases = rawConfig.getKeys("Input-Validation");
+        if (aliases == null) return;
+        for (String alias : aliases) {
+            if (alias == null || alias.isBlank()) continue;
+            String basePath = "Input-Validation." + alias;
+            Set<String> fields = rawConfig.getKeys(basePath);
+            if (fields == null || !fields.contains("Regex")) continue;
+            String regex = rawConfig.getString(basePath + ".Regex");
+            if (regex != null && !regex.isBlank()) {
+                validateRegex(basePath + ".Regex", regex);
+            }
+        }
+    }
 
     // ============================== Screen Mappings ==============================
 

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/sub/DialogConfig.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/sub/DialogConfig.java
@@ -66,6 +66,20 @@ public record DialogConfig(
     ) {
         public static final NumberDefaults DEFAULTS = new NumberDefaults(0.0f, 100.0f, 1.0f, null);
 
+        public NumberDefaults {
+            if (!Float.isFinite(min) || !Float.isFinite(max) || !Float.isFinite(step)
+                    || min >= max || step <= 0.0f
+                    || !Float.isFinite((min + max) / 2.0f)
+                    || (initial != null && !Float.isFinite(initial))) {
+                throw new IllegalArgumentException(
+                        "Dialog number defaults must have finite values with min < max and step > 0");
+            }
+            if (initial != null && (initial < min || initial > max)) {
+                throw new IllegalArgumentException(
+                        "Dialog number initial value must be within the configured range");
+            }
+        }
+
         /** Effective initial value when no override is given: midpoint. */
         public float effectiveInitial() {
             return initial != null ? initial : (min + max) / 2.0f;

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/sub/PlayerUiConfig.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/config/sub/PlayerUiConfig.java
@@ -21,4 +21,14 @@ public record PlayerUiConfig(
         String emptyMessage,
         String worldFilterFormat,
         String radialFilterFormat) {
+
+    public PlayerUiConfig {
+        if (size != 18 && size != 27 && size != 36 && size != 45 && size != 54) {
+            throw new IllegalArgumentException(
+                    "Player UI inventory size must be one of 18, 27, 36, 45, or 54; got " + size);
+        }
+        if (size / 9 - 1 <= 0) {
+            throw new IllegalArgumentException("Player UI page size must be greater than zero");
+        }
+    }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PostCommandPlaceholderResolver.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PostCommandPlaceholderResolver.java
@@ -65,7 +65,13 @@ public class PostCommandPlaceholderResolver {
     var sb = new StringBuilder();
     while (matcher.find()) {
       var digits = matcher.group(1);
-      int idx = (digits == null) ? 1 : Integer.parseInt(digits);
+      int idx;
+      try {
+        idx = (digits == null) ? 1 : Integer.parseInt(digits);
+      } catch (NumberFormatException e) {
+        // An oversized decimal index is invalid but must not abort PCM dispatch.
+        idx = -1;
+      }
       String replacement;
       if (idx >= 1 && idx <= answers.size()) {
         replacement = answers.get(idx - 1);

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PostCommandResolver.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PostCommandResolver.java
@@ -111,12 +111,21 @@ public class PostCommandResolver {
           "Preset post-command '" + def.id() + "' has empty command after placeholder resolution");
       return Optional.empty();
     }
-    return Optional.of(new Resolved(command, def.executeAs(), def.delayTicks(), def.id(), true));
+    return Optional.of(new Resolved(command, def.executeAs(), def.delayTicks(), def.id(), true, false));
   }
 
   private Optional<Resolved> resolveLegacy(
       Player player, PostCommandMeta pcm, boolean wasCancelled) {
-    // Legacy PCMs are pre-filtered by the session's completion state.
+    // Legacy PCMs retain the parser marker as their lifecycle authority. PromptEngine iterates the
+    // union of the parser-prefiltered lists so preset policy can override its source marker; this
+    // explicit check keeps ordinary PCMs from leaking into the opposite lifecycle.
+    if (pcm.onCancel() != wasCancelled) {
+      plugin.getPluginLogger().debug(
+          "Legacy post-command '" + pcm.command()
+              + "' does not match session state (onCancel=" + pcm.onCancel()
+              + ", wasCancelled=" + wasCancelled + ") — skipping");
+      return Optional.empty();
+    }
     if (pcm.command() == null || pcm.command().isEmpty()) {
       plugin.getPluginLogger().debug("Skipping empty legacy PCM");
       return Optional.empty();
@@ -132,7 +141,8 @@ public class PostCommandResolver {
             mapDispatchTarget(pcm.dispatchTarget()),
             pcm.delayTicks(),
             null,
-            false));
+            false,
+            pcm.dispatchTarget() == DispatchTarget.PASSTHROUGH));
   }
 
   private static boolean policyMatches(ExecutionPolicy policy, boolean wasCancelled) {
@@ -160,5 +170,15 @@ public class PostCommandResolver {
    * @param preset whether this command originated from a preset
    */
   public record Resolved(
-      String command, ExecuteAs executeAs, int delayTicks, String sourceId, boolean preset) {}
+      String command,
+      ExecuteAs executeAs,
+      int delayTicks,
+      String sourceId,
+      boolean preset,
+      boolean inheritDispatch) {
+    public Resolved(
+        String command, ExecuteAs executeAs, int delayTicks, String sourceId, boolean preset) {
+      this(command, executeAs, delayTicks, sourceId, preset, false);
+    }
+  }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PromptEngine.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/engine/PromptEngine.java
@@ -3,7 +3,9 @@ package dev.cyr1en.promptpaper.engine;
 import dev.cyr1en.promptcore.*;
 import dev.cyr1en.promptcore.parser.CommandLineParser;
 import dev.cyr1en.promptcore.session.PromptSession;
+import dev.cyr1en.promptcore.i18n.Placeholder;
 import dev.cyr1en.promptpaper.CommandPrompter;
+import dev.cyr1en.promptpaper.preset.ExecuteAs;
 import dev.cyr1en.promptpaper.util.MiniMessageTagFilter;
 import dev.cyr1en.promptpaper.util.Scheduler;
 import java.util.List;
@@ -11,7 +13,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachment;
 
 /**
  * Manages the lifecycle of interactive prompt sessions for players.
@@ -21,16 +26,49 @@ import org.bukkit.entity.Player;
  */
 public class PromptEngine {
 
+    /** Immutable dispatch context captured before ScreenManager clears its per-player maps. */
+    public record DispatchContext(
+            ExecuteAs executeAs,
+            String permissionKey,
+            boolean attachmentRequired,
+            List<String> permissionSnapshot) {
+        public DispatchContext {
+            if (executeAs == null) executeAs = ExecuteAs.PLAYER;
+            permissionSnapshot = permissionSnapshot == null
+                    ? List.of()
+                    : List.copyOf(permissionSnapshot);
+        }
+
+        public DispatchContext(ExecuteAs executeAs, String permissionKey, boolean attachmentRequired) {
+            this(executeAs, permissionKey, attachmentRequired, List.of());
+        }
+
+        public DispatchContext(ExecuteAs executeAs, String permissionKey) {
+            this(executeAs, permissionKey, permissionKey != null, List.of());
+        }
+
+        public static DispatchContext player() {
+            return new DispatchContext(ExecuteAs.PLAYER, null, false, List.of());
+        }
+    }
+
     private final CommandPrompter plugin;
     private volatile CommandLineParser parser;
     private final Map<UUID, PromptSession> sessions;
+    private final Map<SessionResult, List<PostCommandMeta>> dispatchPcmSnapshots;
     private final Scheduler scheduler;
+    private final Object sessionLifecycleMonitor;
+    private final AtomicBoolean reloadInProgress;
 
     public PromptEngine(CommandPrompter plugin, Scheduler scheduler) {
         this.plugin = plugin;
         this.parser = buildParser(plugin);
         this.sessions = new ConcurrentHashMap<>();
+        this.dispatchPcmSnapshots = java.util.Collections.synchronizedMap(
+                new java.util.IdentityHashMap<>());
         this.scheduler = scheduler;
+        this.sessionLifecycleMonitor = new Object();
+        this.reloadInProgress = new AtomicBoolean();
     }
 
     /**
@@ -71,6 +109,66 @@ public class PromptEngine {
     }
 
     /**
+     * Acquires the reload barrier before any player teardown is scheduled.
+     *
+     * <p>The monitor makes the gate transition atomic with the session-creation path. A prompt
+     * that is already in the small hand-off between parsing and screen creation either completes
+     * that hand-off before the barrier is acquired or is rejected before it can create screen
+     * state.
+     *
+     * @return {@code true} when this caller owns the barrier, or {@code false} when another reload
+     *     is already in progress
+     */
+    public boolean beginReload() {
+        synchronized (sessionLifecycleMonitor) {
+            return reloadInProgress.compareAndSet(false, true);
+        }
+    }
+
+    /** Releases the reload barrier after the complete reload attempt has finished. */
+    public void endReload() {
+        synchronized (sessionLifecycleMonitor) {
+            reloadInProgress.set(false);
+        }
+    }
+
+    /** Whether new prompt sessions are currently blocked by a configuration reload. */
+    public boolean isReloadInProgress() {
+        return reloadInProgress.get();
+    }
+
+    /**
+     * Sends the reload-gate feedback when a new player session is rejected.
+     *
+     * <p>This uses an existing localized reload failure key because the message catalog is owned
+     * by the resource/configuration lane. The raw tagged command is still rejected by the caller.
+     */
+    public boolean rejectIfReloading(Player player) {
+        if (!reloadInProgress.get()) return false;
+        try {
+            player.sendMessage(plugin.getConfigLoader().getI18n().get(
+                    "command.reload.failed",
+                    Placeholder.of("error", "a configuration reload is in progress")));
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to send reload-gate feedback: " + e.getMessage());
+        }
+        return true;
+    }
+
+    /**
+     * Runs the final session-to-screen hand-off while holding the same monitor used by the reload
+     * barrier. This prevents a reload from being acquired between session acceptance and creation
+     * of screen/timeout state.
+     */
+    public boolean runIfReloadNotInProgress(Runnable action) {
+        synchronized (sessionLifecycleMonitor) {
+            if (reloadInProgress.get()) return false;
+            action.run();
+            return true;
+        }
+    }
+
+    /**
      * Parses a command line and, if it contains prompt tags, starts a new
      * session for the player and returns the parsed result.
      *
@@ -98,6 +196,7 @@ public class PromptEngine {
      *     (or the command was rejected by the fail-fast check)
      */
     public Optional<ParsedCommand> intercept(Player player, String commandLine) {
+        if (rejectIfReloading(player)) return Optional.empty();
         var config = plugin.getConfigLoader().getConfig();
         if (config.enablePermission() && !player.hasPermission("promptpaper.use")) {
             plugin.getPluginLogger().debug("Player " + player.getName()
@@ -125,7 +224,28 @@ public class PromptEngine {
             return Optional.empty();
         }
 
-        sessions.put(player.getUniqueId(), PromptSession.start(player.getUniqueId().toString(), parsed));
+        var accepted = new AtomicBoolean();
+        boolean rejectedByReload;
+        synchronized (sessionLifecycleMonitor) {
+            rejectedByReload = reloadInProgress.get();
+            if (!rejectedByReload) {
+                sessions.compute(player.getUniqueId(), (uuid, existing) -> {
+                    if (existing != null && existing.isActive()) return existing;
+                    accepted.set(true);
+                    return PromptSession.start(uuid.toString(), parsed);
+                });
+            }
+        }
+        if (rejectedByReload) {
+            rejectIfReloading(player);
+            return Optional.empty();
+        }
+        if (!accepted.get()) {
+            plugin.getPluginLogger().debug("Player " + player.getName()
+                    + " already has an active session, aborting new session");
+            player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.error.session_active"));
+            return Optional.empty();
+        }
         plugin.getPluginLogger().debug("Intercepted " + parsed.promptTags().size()
                 + " prompts for " + player.getName());
         return Optional.of(parsed);
@@ -161,20 +281,31 @@ public class PromptEngine {
      * @return the completed session result if all prompts are now answered, or empty
      */
     public Optional<SessionResult> submit(Player player, String answer) {
-        var session = sessions.get(player.getUniqueId());
-        if (session == null || !session.isActive()) {
+        var found = new AtomicBoolean();
+        var completed = new AtomicReference<SessionResult>();
+        sessions.compute(player.getUniqueId(), (uuid, session) -> {
+            if (session == null || !session.isActive()) return session;
+            found.set(true);
+            var next = session.submitAnswer(answer);
+            if (next.isComplete()) {
+                var result = next.finish();
+                rememberAllPCMs(next, result);
+                completed.set(result);
+                return null;
+            }
+            return next;
+        });
+        if (!found.get()) {
             plugin.getPluginLogger().debug("No active session for " + player.getName() + " on submit");
             return Optional.empty();
         }
-        session = session.submitAnswer(answer);
-        sessions.put(player.getUniqueId(), session);
-        if (session.isComplete()) {
-            sessions.remove(player.getUniqueId());
+        if (completed.get() != null) {
             plugin.getPluginLogger().debug("Session complete for " + player.getName());
-            return Optional.of(session.finish());
+            return Optional.of(completed.get());
         }
+        var session = sessions.get(player.getUniqueId());
         plugin.getPluginLogger().debug("Answer accepted for " + player.getName()
-                + ", " + session.remainingCount() + " remaining");
+                + ", " + (session != null ? session.remainingCount() : 0) + " remaining");
         return Optional.empty();
     }
 
@@ -185,20 +316,31 @@ public class PromptEngine {
      * the size-validation rules.
      */
     public Optional<SessionResult> submitAnswers(Player player, java.util.List<String> answers) {
-        var session = sessions.get(player.getUniqueId());
-        if (session == null || !session.isActive()) {
+        var found = new AtomicBoolean();
+        var completed = new AtomicReference<SessionResult>();
+        sessions.compute(player.getUniqueId(), (uuid, session) -> {
+            if (session == null || !session.isActive()) return session;
+            found.set(true);
+            var next = session.submitAnswers(answers);
+            if (next.isComplete()) {
+                var result = next.finish();
+                rememberAllPCMs(next, result);
+                completed.set(result);
+                return null;
+            }
+            return next;
+        });
+        if (!found.get()) {
             plugin.getPluginLogger().debug("No active session for " + player.getName() + " on submitAnswers");
             return Optional.empty();
         }
-        session = session.submitAnswers(answers);
-        sessions.put(player.getUniqueId(), session);
-        if (session.isComplete()) {
-            sessions.remove(player.getUniqueId());
+        if (completed.get() != null) {
             plugin.getPluginLogger().debug("Session complete for " + player.getName());
-            return Optional.of(session.finish());
+            return Optional.of(completed.get());
         }
+        var session = sessions.get(player.getUniqueId());
         plugin.getPluginLogger().debug("Compound answers accepted for " + player.getName()
-                + ", " + session.remainingCount() + " remaining");
+                + ", " + (session != null ? session.remainingCount() : 0) + " remaining");
         return Optional.empty();
     }
 
@@ -213,16 +355,28 @@ public class PromptEngine {
      * Cancels the player's active session and dispatches on-cancel commands if present.
      */
     public void cancel(Player player, CancelReason reason) {
-        var session = sessions.remove(player.getUniqueId());
-        if (session == null) {
+        cancel(player, reason, DispatchContext.player());
+    }
+
+    /** Atomically cancels a session and dispatches its PCMs with the captured context. */
+    public void cancel(Player player, CancelReason reason, DispatchContext dispatchContext) {
+        var cancelledResult = new AtomicReference<SessionResult>();
+        sessions.compute(player.getUniqueId(), (uuid, session) -> {
+            if (session == null || !session.isActive()) return session;
+            var cancelled = session.cancel(reason);
+            if (cancelled.isCancelled()) {
+                var result = cancelled.finish();
+                rememberAllPCMs(cancelled, result);
+                cancelledResult.set(result);
+            }
+            return null;
+        });
+        if (cancelledResult.get() == null) {
             plugin.getPluginLogger().debug("No session to cancel for " + player.getName());
             return;
         }
         plugin.getPluginLogger().debug("Session cancelled for " + player.getName() + " reason=" + reason);
-        var cancelled = session.cancel(reason);
-        if (cancelled.isCancelled()) {
-            dispatchPCMs(player, cancelled.finish(), true);
-        }
+        dispatchPCMs(player, cancelledResult.get(), true, dispatchContext);
     }
 
     /**
@@ -232,9 +386,32 @@ public class PromptEngine {
         var snapshot = new java.util.ArrayList<>(sessions.keySet());
         for (var uuid : snapshot) {
             var player = plugin.getServer().getPlayer(uuid);
-            if (player != null) cancel(player, CancelReason.MANUAL);
+            if (player == null) {
+                sessions.remove(uuid);
+                continue;
+            }
+            try {
+                var task = player.getScheduler().run(
+                        plugin,
+                        scheduledTask -> cancel(player, CancelReason.MANUAL),
+                        () -> discard(uuid));
+                if (task == null) discard(uuid);
+            } catch (Throwable t) {
+                plugin.getPluginLogger().debug("Unable to cancel session for retired player " + uuid);
+                discard(uuid);
+            }
         }
+    }
+
+    /** Drops session state without dispatching cancellation PCMs. */
+    public void discard(UUID uuid) {
+        if (uuid != null) sessions.remove(uuid);
+    }
+
+    /** Drops all session state without invoking player-affine work. */
+    public void discardAll() {
         sessions.clear();
+        dispatchPcmSnapshots.clear();
     }
 
     /**
@@ -246,6 +423,47 @@ public class PromptEngine {
     }
 
     /**
+     * Remembers the complete parsed PCM source list for a finished result.
+     *
+     * <p>Prompt-core intentionally puts only the marker-matching list in a normal
+     * {@link SessionResult}. The runtime dispatcher must also see the opposite-marker preset
+     * references so their configured execution policy can be authoritative. Legacy references are
+     * re-resolved here and are still filtered by {@link PostCommandResolver} using their marker.
+     */
+    private void rememberAllPCMs(PromptSession finishedSession, SessionResult result) {
+        var all = finishedSession.parsedCommand().postCmds().stream()
+                .map(pcm -> resolvePCMReferences(pcm, result.answers()))
+                .toList();
+        dispatchPcmSnapshots.put(result, all);
+    }
+
+    /** Mirrors the core session's one-pass substitution for the PCMs added from the opposite list. */
+    private PostCommandMeta resolvePCMReferences(PostCommandMeta pcm, List<String> answers) {
+        var matcher = java.util.regex.Pattern.compile("\\{(\\d+)}").matcher(pcm.command());
+        var resolved = new StringBuffer();
+        while (matcher.find()) {
+            int index;
+            try {
+                index = Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException e) {
+                index = -1;
+            }
+            var replacement = index >= 0 && index < answers.size() ? answers.get(index) : "";
+            matcher.appendReplacement(
+                    resolved, java.util.regex.Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(resolved);
+        var command = resolved.toString().replaceAll("\\s+", " ").trim();
+        return new PostCommandMeta(
+                command,
+                pcm.answerIndices(),
+                pcm.delayTicks(),
+                pcm.onCancel(),
+                pcm.dispatchTarget(),
+                pcm.preset());
+    }
+
+    /**
      * Dispatches post-completion or on-cancel commands (PCMs) from a session result.
      *
      * <p>Each PCM is routed through {@link PostCommandResolver}, which:
@@ -253,10 +471,8 @@ public class PromptEngine {
      * <ul>
      *   <li>Resolves preset references ({@code <!@id>}) against the
      *       {@code PresetRegistry}.
-     *   <li>Filters by the preset's {@code executionPolicy} (or, for legacy
-     *       PCMs, by the parser's {@code onCancel} hint, which is already
-     *       aligned with the session state via the pre-filtered
-     *       {@code onCompleteCmds} / {@code onCancelCmds} lists).
+     *   <li>Filters by the preset's {@code executionPolicy}; legacy PCMs retain
+     *       the parser's {@code onCancel} lifecycle hint.
      *   <li>Resolves session-scoped placeholders ({@code {player}},
      *       {@code {input}}, {@code {input:N}}, PAPI {@code %…%}).
      *   <li>Schedules the dispatch with the preset's / legacy delay via the
@@ -266,10 +482,31 @@ public class PromptEngine {
      * <p>Commands with a positive delay are scheduled; others run synchronously.
      */
     public void dispatchPCMs(Player player, SessionResult result, boolean wasCancelled) {
-        var pcms = wasCancelled ? result.onCancelCmds() : result.onCompleteCmds();
+        dispatchPCMs(player, result, wasCancelled, DispatchContext.player());
+    }
+
+    /** Dispatches PCMs using an immutable snapshot of the original dispatch context. */
+    public void dispatchPCMs(
+            Player player,
+            SessionResult result,
+            boolean wasCancelled,
+            DispatchContext dispatchContext) {
+        if (dispatchContext == null) dispatchContext = DispatchContext.player();
+        // SessionResult's public lifecycle lists are parser-prefiltered. The engine keeps an
+        // identity-bound snapshot of the complete parsed PCM source list for results it creates;
+        // use that snapshot so a preset whose source marker disagrees with its configured policy
+        // is still considered. The resolver applies the authoritative preset policy below.
+        List<PostCommandMeta> pcms;
+        synchronized (dispatchPcmSnapshots) {
+            pcms = dispatchPcmSnapshots.remove(result);
+        }
+        if (pcms == null) {
+            pcms = wasCancelled ? result.onCancelCmds() : result.onCompleteCmds();
+        }
         plugin.getPluginLogger().debug("Dispatching " + pcms.size() + " PCMs for "
                 + player.getName() + " (cancelled=" + wasCancelled + ")");
         var resolver = new PostCommandResolver(plugin);
+        var dispatchedPresetIds = new java.util.HashSet<String>();
         for (var pcm : pcms) {
             var resolved = resolver.resolve(player, pcm, wasCancelled, result.answers());
             if (resolved.isEmpty()) {
@@ -279,26 +516,75 @@ public class PromptEngine {
                                 + " onCancel=" + pcm.onCancel());
                 continue;
             }
-            schedule(player, resolved.get());
+            if (resolved.get().preset()
+                    && !dispatchedPresetIds.add(resolved.get().sourceId())) {
+                plugin.getPluginLogger().debug(
+                        "Skipping duplicate preset PCM: " + resolved.get().sourceId());
+                continue;
+            }
+            schedule(player, resolved.get(), dispatchContext);
         }
     }
 
     /** Schedules a single resolved post-command for execution. */
-    private void schedule(Player player, PostCommandResolver.Resolved resolved) {
-        Runnable task = () -> executeResolved(player, resolved);
+    private void schedule(
+            Player player,
+            PostCommandResolver.Resolved resolved,
+            DispatchContext dispatchContext) {
+        var effectiveExecuteAs = resolved.inheritDispatch()
+                ? dispatchContext.executeAs()
+                : resolved.executeAs();
+        if (effectiveExecuteAs == ExecuteAs.PLAYER) {
+            if (resolved.delayTicks() > 0) {
+                plugin.getPluginLogger().debug(
+                        "Scheduling PCM: source=" + resolved.sourceId()
+                                + " preset=" + resolved.preset()
+                                + " delay=" + resolved.delayTicks() + "t"
+                                + " target=" + effectiveExecuteAs
+                                + " cmd=" + resolved.command());
+                try {
+                    player.getScheduler().runDelayed(
+                            plugin,
+                            scheduledTask -> executeResolved(player, resolved, dispatchContext),
+                            null,
+                            resolved.delayTicks());
+                } catch (Throwable t) {
+                    plugin.getPluginLogger().debug("Player PCM task retired before scheduling: "
+                            + t.getMessage());
+                }
+            } else {
+                plugin.getPluginLogger().debug(
+                        "Dispatching PCM: source=" + resolved.sourceId()
+                                + " preset=" + resolved.preset()
+                                + " target=" + effectiveExecuteAs
+                                + " cmd=" + resolved.command());
+                try {
+                    player.getScheduler().run(
+                            plugin,
+                            scheduledTask -> executeResolved(player, resolved, dispatchContext),
+                            null);
+                } catch (Throwable t) {
+                    plugin.getPluginLogger().debug("Player PCM task retired before scheduling: "
+                            + t.getMessage());
+                }
+            }
+            return;
+        }
+
+        Runnable task = () -> executeResolved(player, resolved, dispatchContext);
         if (resolved.delayTicks() > 0) {
             plugin.getPluginLogger().debug(
                     "Scheduling PCM: source=" + resolved.sourceId()
                             + " preset=" + resolved.preset()
                             + " delay=" + resolved.delayTicks() + "t"
-                            + " target=" + resolved.executeAs()
+                            + " target=" + effectiveExecuteAs
                             + " cmd=" + resolved.command());
             scheduler.runLater(task, resolved.delayTicks());
         } else {
             plugin.getPluginLogger().debug(
                     "Dispatching PCM: source=" + resolved.sourceId()
                             + " preset=" + resolved.preset()
-                            + " target=" + resolved.executeAs()
+                            + " target=" + effectiveExecuteAs
                             + " cmd=" + resolved.command());
             scheduler.runSync(task);
         }
@@ -310,12 +596,154 @@ public class PromptEngine {
      * the server console; {@link dev.cyr1en.promptpaper.preset.ExecuteAs#PLAYER}
      * uses the player.
      */
-    private void executeResolved(Player player, PostCommandResolver.Resolved resolved) {
-        var sender = switch (resolved.executeAs()) {
+    private void executeResolved(
+            Player player,
+            PostCommandResolver.Resolved resolved,
+            DispatchContext dispatchContext) {
+        var executeAs = resolved.inheritDispatch()
+                ? dispatchContext.executeAs()
+                : resolved.executeAs();
+        if (resolved.inheritDispatch()
+                && executeAs == ExecuteAs.PLAYER
+                && dispatchContext.attachmentRequired()) {
+            executeWithAttachment(
+                    player,
+                    resolved.command(),
+                    dispatchContext.permissionKey(),
+                    dispatchContext.permissionSnapshot(),
+                    resolved.delayTicks() > 0);
+            return;
+        }
+        var sender = switch (executeAs) {
             case CONSOLE -> plugin.getServer().getConsoleSender();
             case PLAYER -> player;
         };
-        plugin.getServer().dispatchCommand(sender, resolved.command());
+        try {
+            if (!plugin.getServer().dispatchCommand(sender, resolved.command())) {
+                reportCommandFailure(player, resolved.command(), "dispatch returned false");
+            }
+        } catch (Exception e) {
+            reportCommandFailure(player, resolved.command(), e.getMessage());
+        }
+    }
+
+    private void executeWithAttachment(
+            Player player,
+            String command,
+            String permissionKey,
+            List<String> capturedPermissions,
+            boolean delayed) {
+        if (permissionKey == null || permissionKey.isBlank()
+                || capturedPermissions == null || capturedPermissions.isEmpty()) {
+            plugin.getPluginLogger().err(
+                    "Refusing post-command attachment dispatch for invalid captured key/snapshot: "
+                            + permissionKey);
+            reportCommandFailure(player, command, "invalid permission attachment");
+            return;
+        }
+
+        if (delayed) {
+            var currentPermissions = readPermissionSnapshot(permissionKey);
+            if (currentPermissions.isEmpty()) {
+                plugin.getPluginLogger().err(
+                        "Skipping delayed attachment PCM '" + command
+                                + "': permission key was removed or is unavailable: "
+                                + permissionKey);
+                reportCommandFailure(player, command, "permission attachment changed after scheduling");
+                return;
+            }
+            if (!currentPermissions.get().equals(capturedPermissions)) {
+                plugin.getPluginLogger().err(
+                        "Skipping delayed attachment PCM '" + command
+                                + "': permissions for key " + permissionKey
+                                + " changed from " + capturedPermissions + " to "
+                                + currentPermissions.get());
+                reportCommandFailure(player, command, "permission attachment changed after scheduling");
+                return;
+            }
+        }
+
+        var permissions = capturedPermissions.toArray(new String[0]);
+        var config = plugin.getConfigLoader().getConfig();
+
+        var attachment = new AtomicReference<PermissionAttachment>();
+        var removed = new AtomicBoolean();
+        Runnable remove = () -> {
+            var current = attachment.get();
+            if (current != null && removed.compareAndSet(false, true)) {
+                try {
+                    player.removeAttachment(current);
+                } catch (Exception e) {
+                    plugin.getPluginLogger().debug("Unable to remove permission attachment");
+                }
+            }
+        };
+        boolean removalScheduled = false;
+        boolean failed = false;
+        try {
+            attachment.set(player.addAttachment(plugin));
+            if (attachment.get() == null) {
+                reportCommandFailure(player, command, "unable to create permission attachment");
+                return;
+            }
+            for (var permission : permissions) attachment.get().setPermission(permission, true);
+            attachment.get().getPermissible().recalculatePermissions();
+            if (!plugin.getServer().dispatchCommand(player, command)) {
+                reportCommandFailure(player, command, "dispatch returned false");
+            }
+        } catch (Exception e) {
+            failed = true;
+            reportCommandFailure(player, command, e.getMessage());
+        }
+        if (!failed && !removed.get() && config != null && config.permissionAttachmentTicks() > 0) {
+            try {
+                var task = player.getScheduler().runDelayed(
+                        plugin,
+                        scheduledTask -> remove.run(),
+                        () -> {},
+                        config.permissionAttachmentTicks());
+                removalScheduled = task != null;
+            } catch (Exception e) {
+                plugin.getPluginLogger().debug("Attachment removal scheduling failed: "
+                        + e.getMessage());
+            }
+        }
+        if (!removalScheduled) remove.run();
+    }
+
+    /** Reads the current attachment definition only for delayed fail-closed validation. */
+    private Optional<List<String>> readPermissionSnapshot(String permissionKey) {
+        if (permissionKey == null || permissionKey.isBlank()) return Optional.empty();
+        try {
+            var config = plugin.getConfigLoader().getConfig();
+            var permissions = config == null ? null : config.getPermissionAttachment(permissionKey);
+            if (permissions == null || permissions.length == 0) return Optional.empty();
+            return Optional.of(List.copyOf(java.util.Arrays.asList(permissions)));
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug(
+                    "Unable to revalidate permission attachment key " + permissionKey + ": "
+                            + e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private void reportCommandFailure(Player player, String command, String detail) {
+        var message = detail != null ? detail : "unknown error";
+        plugin.getPluginLogger().info("Command dispatch failed for '" + command + "': " + message);
+        try {
+            var task = player.getScheduler().run(
+                    plugin,
+                    scheduledTask -> player.sendMessage(plugin.getConfigLoader().getI18n().get(
+                            "prompt.error.command_failed",
+                            player,
+                            Placeholder.of("message", message))),
+                    null);
+            if (task == null) {
+                plugin.getPluginLogger().debug("Unable to send command failure to retired player");
+            }
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to send command failure feedback: " + e.getMessage());
+        }
     }
 
     // ------------------------------------------------------------------

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/factory/PromptFactory.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/factory/PromptFactory.java
@@ -15,6 +15,7 @@ import dev.cyr1en.promptui.ScreenProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.ServiceConfigurationError;
 import org.bukkit.entity.Player;
 
 /**
@@ -56,6 +57,8 @@ import org.bukkit.entity.Player;
  */
 public class PromptFactory {
 
+  private static final List<String> SUPPORTED_TARGETS = List.of("26.1", "26.2");
+
   private final CommandPrompter plugin;
   private final List<ScreenProvider> providers;
   private final MaterialMapper materialMapper;
@@ -75,14 +78,20 @@ public class PromptFactory {
       for (var provider : loader) {
         loaded.add(provider);
       }
-    } catch (Exception e) {
+    } catch (ServiceConfigurationError | LinkageError e) {
+      plugin.getPluginLogger().warn("Failed to load screen providers: " + e.getMessage());
+    } catch (RuntimeException e) {
       plugin.getPluginLogger().warn("Failed to load screen providers: " + e.getMessage());
     }
 
+    String serverVersion = org.bukkit.Bukkit.getMinecraftVersion();
     if (loaded.isEmpty()) {
       plugin.getPluginLogger().info("No GUI screen providers found — GUI prompts will fall back to chat.");
+      plugin.getPluginLogger().warn("Supported screen targets: " + SUPPORTED_TARGETS
+          + "; current server version: " + serverVersion + ".");
     } else {
-      // Sort providers descending to fall back to the newest available NMS module.
+      // Prefer the highest matching target when more than one module is on the
+      // class path. An unmatched server deliberately leaves this list empty.
       loaded.sort((p1, p2) -> {
         String t1 = p1.getTargetVersion();
         String t2 = p2.getTargetVersion();
@@ -103,7 +112,6 @@ public class PromptFactory {
         return 0;
       });
 
-      String serverVersion = org.bukkit.Bukkit.getMinecraftVersion();
       ScreenProvider bestMatch = null;
       
       for (var provider : loaded) {
@@ -118,12 +126,9 @@ public class PromptFactory {
         providers.add(bestMatch);
         plugin.getPluginLogger().info("Loaded screen provider for Minecraft " + serverVersion + ": " + bestMatch.getClass().getName());
       } else {
-        // Fallback to the newest provider.
-        bestMatch = loaded.get(0);
-        providers.add(bestMatch);
-        plugin.getPluginLogger().warn("No specific NMS module found for Minecraft " + serverVersion + ".");
-        plugin.getPluginLogger().warn("Falling back to the NMS module for " + bestMatch.getTargetVersion() + " (" + bestMatch.getClass().getSimpleName() + ").");
-        plugin.getPluginLogger().warn("Most features should still work, but some GUI elements might fall back to chat if internal server code has changed.");
+        plugin.getPluginLogger().warn("No screen provider matches Minecraft " + serverVersion + ".");
+        plugin.getPluginLogger().warn("Supported screen targets: " + SUPPORTED_TARGETS
+            + "; current server version: " + serverVersion + ". GUI prompts will fall back to chat.");
       }
     }
 

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/HookContainer.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/HookContainer.java
@@ -3,7 +3,12 @@ package dev.cyr1en.promptpaper.hook;
 import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.hook.annotations.TargetPlugin;
 import dev.cyr1en.promptpaper.hook.hooks.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 
@@ -16,9 +21,22 @@ import org.bukkit.event.Listener;
  */
 public class HookContainer {
 
+    /** Hook order is also the selection priority for hooks sharing an extension point. */
+    private static final List<Class<? extends PluginHook>> HOOK_TYPES = List.of(
+            PremiumVanishHook.class,
+            SuperVanishHook.class,
+            CarbonChatHook.class,
+            VanishNoPacketHook.class,
+            PapiHook.class,
+            TownyHook.class,
+            LuckPermsHook.class,
+            HuskTownsHook.class,
+            WorldGuardHook.class);
+
     private final CommandPrompter plugin;
-    private final Map<Class<?>, PluginHook> hooks = new HashMap<>();
-    private final Map<Class<?>, String> targetPlugins = new HashMap<>();
+    private final Map<Class<?>, PluginHook> hooks = new LinkedHashMap<>();
+    private final Map<Class<?>, String> targetPlugins = new LinkedHashMap<>();
+    private boolean initialized;
 
     public HookContainer(CommandPrompter plugin) {
         this.plugin = plugin;
@@ -29,18 +47,17 @@ public class HookContainer {
      * silently if its {@link TargetPlugin} is not installed on the server.
      */
     public void initHooks() {
+        if (initialized) {
+            plugin.getPluginLogger().debug("Hooks already initialized; keeping existing registrations");
+            return;
+        }
+        initialized = true;
         plugin.getPluginLogger().debug("Initializing hooks...");
-        hook(PremiumVanishHook.class);
-        hook(SuperVanishHook.class);
-        hook(CarbonChatHook.class);
-        hook(VanishNoPacketHook.class);
-        hook(PapiHook.class);
-        hook(TownyHook.class);
-        hook(LuckPermsHook.class);
-        hook(HuskTownsHook.class);
-        hook(WorldGuardHook.class);
-        var hookedCount = hooks.size();
-        plugin.getPluginLogger().debug("Hooks initialized: " + hookedCount + "/" + hooks.size() + " active");
+        for (var type : HOOK_TYPES) {
+            hook(type);
+        }
+        plugin.getPluginLogger().debug(
+                "Hooks initialized: " + hooks.size() + "/" + HOOK_TYPES.size() + " active");
     }
 
     /**
@@ -48,11 +65,25 @@ public class HookContainer {
      * Skips silently if the target plugin is missing or the annotation is absent.
      */
     private <T extends PluginHook> void hook(Class<T> type) {
-        var instance = constructHook(type);
-        if (instance == null) return;
-        hooks.put(type, instance);
-        plugin.getPluginLogger().info(" \u2713 " + type.getSimpleName() + " hooked");
-        instance.onEnable();
+        try {
+            var instance = constructHook(type);
+            if (instance == null) return;
+
+            // Run optional API initialization before exposing the hook to selectors. If the
+            // provider throws, only this hook is skipped and the remaining integrations continue.
+            instance.onEnable();
+            registerListener(type, instance);
+            hooks.put(type, instance);
+            var annotation = type.getAnnotation(TargetPlugin.class);
+            if (annotation != null) targetPlugins.put(type, annotation.pluginName());
+            plugin.getPluginLogger().info(" \u2713 " + type.getSimpleName() + " hooked");
+        } catch (ServiceConfigurationError e) {
+            logHookFailure(type, e);
+        } catch (LinkageError e) {
+            logHookFailure(type, e);
+        } catch (Exception e) {
+            logHookFailure(type, e);
+        }
     }
 
     /**
@@ -61,33 +92,62 @@ public class HookContainer {
      * the annotation is absent, or the required constructor is not found.
      */
     private <T extends PluginHook> T constructHook(Class<T> type) {
-        var ann = type.getAnnotation(TargetPlugin.class);
-        if (ann == null) {
-            plugin.getPluginLogger().debug("Skipping " + type.getSimpleName() + ": no @TargetPlugin annotation");
-            return null;
-        }
-
-        var target = ann.pluginName();
-        if (!Bukkit.getPluginManager().isPluginEnabled(target)) {
-            plugin.getPluginLogger().debug("Skipping " + type.getSimpleName() + ": " + target + " not installed");
-            return null;
-        }
-
         try {
+            var ann = type.getAnnotation(TargetPlugin.class);
+            if (ann == null) {
+                plugin.getPluginLogger().debug(
+                        "Skipping " + type.getSimpleName() + ": no @TargetPlugin annotation");
+                return null;
+            }
+
+            var target = ann.pluginName();
+            if (!Bukkit.getPluginManager().isPluginEnabled(target)) {
+                plugin.getPluginLogger().debug(
+                        "Skipping " + type.getSimpleName() + ": " + target + " not installed");
+                return null;
+            }
+
             var ctor = type.getDeclaredConstructor(CommandPrompter.class);
             var instance = ctor.newInstance(plugin);
-            if (instance instanceof Listener listener)
-                Bukkit.getPluginManager().registerEvents(listener, plugin);
-            targetPlugins.put(type, target);
             return instance;
         } catch (NoSuchMethodException e) {
-            plugin.getPluginLogger().err("Hook " + type.getSimpleName()
-                    + " is missing required constructor (CommandPrompter)");
+            plugin.getPluginLogger().err(
+                    "Hook " + type.getSimpleName()
+                            + " is missing required constructor (CommandPrompter)");
+            return null;
+        } catch (ServiceConfigurationError e) {
+            logHookFailure(type, e);
+            return null;
+        } catch (LinkageError e) {
+            logHookFailure(type, e);
             return null;
         } catch (Exception e) {
-            plugin.getPluginLogger().err("Failed to construct hook " + type.getSimpleName() + ": " + e.getMessage());
+            logHookFailure(type, e);
             return null;
         }
+    }
+
+    /** Registers a listener after successful optional-API initialization. */
+    private void registerListener(Class<?> type, PluginHook hook) {
+        if (!(hook instanceof Listener listener)) return;
+
+        // PremiumVanish exposes the SuperVanish event/API and PremiumVanishHook inherits the
+        // listener method. Registering both instances makes every vanish event invalidate the
+        // cache twice when both plugins are installed. PremiumVanish has explicit priority above
+        // SuperVanish, so retain the first listener and keep the second hook API-only.
+        if (type == SuperVanishHook.class && hooks.containsKey(PremiumVanishHook.class)) {
+            plugin.getPluginLogger().debug(
+                    "Skipping inherited SuperVanish listener because PremiumVanish is already hooked");
+            return;
+        }
+        Bukkit.getPluginManager().registerEvents(listener, plugin);
+    }
+
+    private void logHookFailure(Class<?> type, Throwable failure) {
+        var message = failure.getMessage();
+        plugin.getPluginLogger().err(
+                "Skipping hook " + type.getSimpleName() + ": "
+                        + (message == null ? failure.getClass().getSimpleName() : message));
     }
 
     /** Returns the Bukkit plugin name that the given hook type targets, if known. */
@@ -96,10 +156,12 @@ public class HookContainer {
     }
 
     /** Returns the registered hook instance of the given type, if present. */
+    @SuppressWarnings("unchecked")
     public <T> Optional<T> getHook(Class<T> type) {
         return Optional.ofNullable((T) hooks.get(type));
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends PluginHook> Optional<T> getPluginHook(Class<T> type) {
         return Optional.ofNullable((T) hooks.get(type));
     }
@@ -126,6 +188,20 @@ public class HookContainer {
     /** Calls {@link PluginHook#onDisable()} on every registered hook. */
     public void disableAll() {
         plugin.getPluginLogger().debug("Disabling all hooks...");
-        hooks.values().forEach(PluginHook::onDisable);
+        // Disable in reverse registration order so selected fallbacks remain available until
+        // higher-priority integrations have released their resources.
+        var registered = new ArrayList<>(hooks.values());
+        for (var i = registered.size() - 1; i >= 0; i--) {
+            var hook = registered.get(i);
+            try {
+                hook.onDisable();
+            } catch (ServiceConfigurationError e) {
+                logHookFailure(hook.getClass(), e);
+            } catch (LinkageError e) {
+                logHookFailure(hook.getClass(), e);
+            } catch (Exception e) {
+                logHookFailure(hook.getClass(), e);
+            }
+        }
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/hooks/CarbonChatHook.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/hooks/CarbonChatHook.java
@@ -4,9 +4,11 @@ import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.hook.annotations.TargetPlugin;
 import dev.cyr1en.promptpaper.screen.ScreenManager;
 import net.draycia.carbon.api.CarbonChatProvider;
+import net.draycia.carbon.api.event.CarbonEventSubscription;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
+import java.util.ServiceConfigurationError;
 
 /**
  * Hook for the CarbonChat plugin. Subscribes to CarbonChat's event bus
@@ -15,6 +17,9 @@ import org.bukkit.Bukkit;
  */
 @TargetPlugin(pluginName = "CarbonChat")
 public class CarbonChatHook extends BaseHook implements ChatListenerHook {
+
+    private CarbonEventSubscription<CarbonChatEvent> subscription;
+    private boolean available;
 
     public CarbonChatHook(CommandPrompter plugin) {
         super(plugin);
@@ -26,22 +31,94 @@ public class CarbonChatHook extends BaseHook implements ChatListenerHook {
      */
     @Override
     public boolean subscribe(ScreenManager screenManager) {
-        var cc = CarbonChatProvider.carbonChat();
+        disposeSubscription();
+
+        final var cc = getCarbonChat();
         if (cc == null) {
-            getPlugin().getPluginLogger().debug("CarbonChat not available, subscription failed");
             return false;
         }
-        getPlugin().getPluginLogger().debug("Subscribing to CarbonChat events");
-        cc.eventHandler().subscribe(CarbonChatEvent.class, -100, false, event -> {
-            var player = Bukkit.getPlayer(event.sender().uuid());
-            if (player == null || !screenManager.hasChatScreen(player)) return;
-            event.cancelled(true);
-            event.recipients().clear();
-            var msg = PlainTextComponentSerializer.plainText().serialize(event.message());
-            getPlugin().getPluginLogger().debug("CarbonChat captured: player=" + player.getName()
-                    + " msg=" + msg);
-            player.getScheduler().run(getPlugin(), st -> screenManager.handleChatInput(player, msg), null);
-        });
-        return true;
+
+        try {
+            getPlugin().getPluginLogger().debug("Subscribing to CarbonChat events");
+            var registered = cc.eventHandler().subscribe(CarbonChatEvent.class, -100, false, event -> {
+                var player = Bukkit.getPlayer(event.sender().uuid());
+                if (player == null || !screenManager.hasChatScreen(player)) return;
+                event.cancelled(true);
+                event.recipients().clear();
+                var msg = PlainTextComponentSerializer.plainText().serialize(event.message());
+                getPlugin().getPluginLogger().debug("CarbonChat captured: player=" + player.getName()
+                        + " msg=" + msg);
+                player.getScheduler().run(getPlugin(), st -> screenManager.handleChatInput(player, msg), null);
+            });
+            if (registered == null) {
+                available = false;
+                getPlugin().getPluginLogger().debug("CarbonChat returned no subscription handle");
+                return false;
+            }
+            subscription = registered;
+            available = true;
+            return true;
+        } catch (ServiceConfigurationError e) {
+            markUnavailable("CarbonChat event API could not be configured", e);
+        } catch (LinkageError e) {
+            markUnavailable("CarbonChat event API is unavailable", e);
+        } catch (Exception e) {
+            markUnavailable("CarbonChat subscription failed", e);
+        }
+        return false;
+    }
+
+    /**
+     * CarbonChat throws {@link IllegalStateException} until its provider has been initialized.
+     * Treat that state as a normal optional-hook miss so the Bukkit listener can be selected.
+     */
+    private net.draycia.carbon.api.CarbonChat getCarbonChat() {
+        try {
+            var cc = CarbonChatProvider.carbonChat();
+            if (cc == null) {
+                markUnavailable("CarbonChat provider returned null", null);
+                return null;
+            }
+            return cc;
+        } catch (IllegalStateException e) {
+            markUnavailable("CarbonChat is not initialized", e);
+        } catch (ServiceConfigurationError e) {
+            markUnavailable("CarbonChat provider could not be configured", e);
+        } catch (LinkageError e) {
+            markUnavailable("CarbonChat provider is unavailable", e);
+        } catch (Exception e) {
+            markUnavailable("CarbonChat provider lookup failed", e);
+        }
+        return null;
+    }
+
+    @Override
+    public void onDisable() {
+        disposeSubscription();
+        available = false;
+    }
+
+    private void disposeSubscription() {
+        var current = subscription;
+        subscription = null;
+        if (current == null) return;
+        try {
+            current.dispose();
+        } catch (ServiceConfigurationError e) {
+            markUnavailable("CarbonChat subscription disposal failed", e);
+        } catch (LinkageError e) {
+            markUnavailable("CarbonChat subscription disposal failed", e);
+        } catch (Exception e) {
+            markUnavailable("CarbonChat subscription disposal failed", e);
+        }
+    }
+
+    private void markUnavailable(String message, Throwable failure) {
+        available = false;
+        if (failure == null) {
+            getPlugin().getPluginLogger().debug(message);
+        } else {
+            getPlugin().getPluginLogger().debug(message + ": " + failure.getMessage());
+        }
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/hooks/LuckPermsHook.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/hook/hooks/LuckPermsHook.java
@@ -5,6 +5,7 @@ import dev.cyr1en.promptpaper.hook.annotations.TargetPlugin;
 import dev.cyr1en.promptpaper.screen.playerui.CacheFilter;
 import dev.cyr1en.promptpaper.screen.playerui.HeadCache;
 import java.util.List;
+import java.util.ServiceConfigurationError;
 import java.util.regex.Pattern;
 import net.luckperms.api.LuckPerms;
 import org.bukkit.Bukkit;
@@ -22,12 +23,24 @@ public class LuckPermsHook extends BaseHook implements FilterHook {
 
     public LuckPermsHook(CommandPrompter plugin) {
         super(plugin);
-        var provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
-        if (provider != null) this.api = provider.getProvider();
+        try {
+            var provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+            if (provider != null) this.api = provider.getProvider();
+        } catch (ServiceConfigurationError e) {
+            plugin.getPluginLogger().debug("LuckPerms API service is unavailable: " + e.getMessage());
+        } catch (LinkageError e) {
+            plugin.getPluginLogger().debug("LuckPerms API linkage is unavailable: " + e.getMessage());
+        } catch (RuntimeException e) {
+            plugin.getPluginLogger().debug("LuckPerms API service lookup failed: " + e.getMessage());
+        }
     }
 
     @Override
     public void registerFilters(HeadCache cache) {
+        if (api == null) {
+            getPlugin().getPluginLogger().debug("LuckPerms unavailable; no LuckPerms filters registered");
+            return;
+        }
         cache.registerFilter(new OwnGroupFilter());
         cache.registerFilter(new GroupFilter());
     }
@@ -37,13 +50,35 @@ public class LuckPermsHook extends BaseHook implements FilterHook {
      */
     private List<Player> getPlayersWithGroup(String groupName) {
         if (api == null || groupName.isBlank()) return List.of();
-        return Bukkit.getOnlinePlayers().stream()
-                .<Player>map(p -> p)
-                .filter(p -> {
-                    var user = api.getUserManager().getUser(p.getUniqueId());
-                    if (user == null) return false;
-                    return user.getPrimaryGroup().equals(groupName);
-                }).toList();
+        try {
+            if (api.getUserManager() == null) return List.of();
+            return Bukkit.getOnlinePlayers().stream()
+                    .<Player>map(p -> p)
+                    .filter(p -> groupName.equals(getPrimaryGroup(p)))
+                    .toList();
+        } catch (ServiceConfigurationError e) {
+            return List.of();
+        } catch (LinkageError e) {
+            return List.of();
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    private String getPrimaryGroup(Player player) {
+        if (api == null || player == null) return null;
+        try {
+            var userManager = api.getUserManager();
+            if (userManager == null) return null;
+            var user = userManager.getUser(player.getUniqueId());
+            return user == null ? null : user.getPrimaryGroup();
+        } catch (ServiceConfigurationError e) {
+            return null;
+        } catch (LinkageError e) {
+            return null;
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     private class OwnGroupFilter extends CacheFilter {
@@ -52,9 +87,8 @@ public class LuckPermsHook extends BaseHook implements FilterHook {
         }
         @Override public CacheFilter reConstruct(String promptKey) { return this; }
         @Override public List<Player> filter(Player relative) {
-            var user = api.getUserManager().getUser(relative.getUniqueId());
-            if (user == null) return List.of();
-            return getPlayersWithGroup(user.getPrimaryGroup());
+            var group = getPrimaryGroup(relative);
+            return group == null ? List.of() : getPlayersWithGroup(group);
         }
     }
 

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/listener/ChatPromptListener.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/listener/ChatPromptListener.java
@@ -4,7 +4,6 @@ import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.screen.ScreenManager;
 import dev.cyr1en.promptui.ComponentUtil;
 import io.papermc.paper.event.player.AsyncChatEvent;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
@@ -29,7 +28,6 @@ public class ChatPromptListener implements Listener {
      * cancels the event to prevent the message from reaching other listeners,
      * and forwards the serialized text to the screen manager on the player's scheduler.
      */
-    @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerChat(AsyncChatEvent event) {
         var player = event.getPlayer();
         plugin.getPluginLogger().debug("Chat event: player=" + player.getName()
@@ -40,9 +38,16 @@ public class ChatPromptListener implements Listener {
         event.setCancelled(true);
         var message = event.message();
         plugin.getPluginLogger().debug("Chat input captured for " + player.getName());
-        player.getScheduler().run(plugin, scheduledTask -> {
-            screenManager.handleChatInput(player, ComponentUtil.serialize(message));
-        }, null);
+        try {
+            var task = player.getScheduler().run(plugin, scheduledTask -> {
+                screenManager.handleChatInput(player, ComponentUtil.serialize(message));
+            }, null);
+            if (task == null) {
+                plugin.getPluginLogger().debug("Chat input task retired for " + player.getUniqueId());
+            }
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to schedule chat input: " + e.getMessage());
+        }
     }
 
     /**
@@ -52,7 +57,7 @@ public class ChatPromptListener implements Listener {
     public EventPriority resolvePriority() {
         var configPriority = plugin.getConfigLoader().getPromptConfig().responseListenerPriority();
         try {
-            return EventPriority.valueOf(configPriority.toUpperCase());
+            return EventPriority.valueOf(configPriority.trim().toUpperCase());
         } catch (Exception e) {
             return EventPriority.LOWEST;
         }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/listener/PlayerCommandListener.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/listener/PlayerCommandListener.java
@@ -60,12 +60,22 @@ public class PlayerCommandListener implements Listener {
         plugin.getPluginLogger().debug("Command received: player=" + player.getName()
                 + " cmd=" + commandName + " hasScreen=" + hasActiveScreen);
 
-        if (commandName.startsWith("commandprompter") || commandName.startsWith("cmdp")) {
+        if (commandName.equals("commandprompter") || commandName.equals("cmdp")) {
             plugin.getPluginLogger().debug("Command is plugin command, not intercepting");
             return;
         }
 
         var config = plugin.getConfigLoader().getConfig();
+        var commandLine = message.startsWith("/") ? message.substring(1) : message;
+        if (engine != null
+                && engine.isReloadInProgress()
+                && engine.commandHasTagForm(commandLine)) {
+            // Do not let a tagged command fall through while ReloadCommand is still tearing down
+            // other players. The engine also supplies localized feedback for the rejected session.
+            event.setCancelled(true);
+            engine.rejectIfReloading(player);
+            return;
+        }
         if (config.ignoredCommands().stream()
                 .anyMatch(c -> c.equalsIgnoreCase(commandName))) {
             plugin.getPluginLogger().debug("Command is in ignored-commands list, not intercepting");
@@ -78,14 +88,22 @@ public class PlayerCommandListener implements Listener {
             event.setCancelled(true);
         }
 
-        var commandLine = message.startsWith("/") ? message.substring(1) : message;
-
         // Cancel the event if a session starts or the command references a preset.
         if (engine != null && engine.commandHasTagForm(commandLine)) {
             var allowedToUse = !config.enablePermission() || player.hasPermission("promptpaper.use");
             if (allowedToUse) {
-                screenManager.startSession(player, commandLine);
-                if (screenManager.hasActiveScreen(player) || engine.hasPresetReferences(commandLine)) {
+                try {
+                    screenManager.startSession(player, commandLine);
+                } catch (Throwable e) {
+                    screenManager.discardState(player.getUniqueId());
+                    plugin.getPluginLogger().err("Prompt screen failed for " + player.getName()
+                            + ": " + e.getMessage());
+                    event.setCancelled(true);
+                    return;
+                }
+                if (screenManager.hasActiveScreen(player)
+                        || engine.hasPresetReferences(commandLine)
+                        || engine.isReloadInProgress()) {
                     plugin.getPluginLogger().debug("Command had prompts/presets, cancelling event");
                     event.setCancelled(true);
                 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/preset/PresetRegistry.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/preset/PresetRegistry.java
@@ -1,12 +1,18 @@
 package dev.cyr1en.promptpaper.preset;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonParseException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +42,8 @@ import org.bukkit.plugin.java.JavaPlugin;
  *
  * <h2>Failure semantics</h2>
  *
- * <p>I/O and parse failures throw {@link PresetLoadException}. The previous cache is left
- * untouched so a broken edit on disk does not silently wipe live presets.
+ * <p>I/O, JSON, and preset-constructor validation failures throw {@link PresetLoadException}. The
+ * previous cache is left untouched so a broken edit on disk does not silently wipe live presets.
  */
 public class PresetRegistry {
 
@@ -85,7 +91,8 @@ public class PresetRegistry {
    * <ol>
    *   <li>If the file is missing, extract the bundled default resource (no-op when this
    *       instance was built via the test-only constructor and the supplier is {@code null}).
-   *   <li>Read and parse the file as a {@link PresetConfig}.
+   *   <li>Read and parse the JSON document, then deserialize each entry independently so failures
+   *       can identify the preset id and array path.
    *   <li>Build immutable prompt and post-command maps keyed by {@code id}.
    *   <li>Atomically swap them in via the {@code volatile} references.
    * </ol>
@@ -97,23 +104,35 @@ public class PresetRegistry {
     try {
       ensureFileExists();
       try (var reader = Files.newBufferedReader(promptsFile.toPath(), StandardCharsets.UTF_8)) {
-        var config = gson.fromJson(reader, PresetConfig.class);
-        if (config == null) {
+        var document = JsonParser.parseReader(reader);
+        if (document == null || document.isJsonNull()) {
           // Gson returns null for an empty document. Treat as cleared.
           this.prompts = Map.of();
           this.postCommands = Map.of();
           logInfo("presets.json is empty; registry cleared");
           return;
         }
-        var newPrompts = buildIdMap(
-            config.prompts(), PromptDefinition::id, "prompt", this::logWarning);
-        var newPostCommands = buildIdMap(
-            config.postCommands(), PostCommand::id, "post-command", this::logWarning);
+        if (!document.isJsonObject()) {
+          throw malformed("document", "<root>", "root",
+              new IllegalArgumentException("expected a JSON object"));
+        }
+        var root = document.getAsJsonObject();
+        var newPrompts = loadPrompts(root);
+        var newPostCommands = loadPostCommands(root);
         this.prompts = newPrompts;
         this.postCommands = newPostCommands;
       }
-    } catch (IOException | JsonParseException e) {
-      throw new PresetLoadException("Failed to load " + FILE_NAME + ": " + e.getMessage(), e);
+    } catch (PresetLoadException e) {
+      throw e;
+    } catch (IOException | JsonParseException | IllegalArgumentException | NullPointerException e) {
+      throw new PresetLoadException(
+          "Failed to load presets from '" + sourcePath() + "': " + safeMessage(e), e);
+    } catch (RuntimeException e) {
+      // Gson and record adapters can surface other runtime validation failures (for example
+      // JsonSyntaxException wrappers). Reload must expose one predictable failure type and keep
+      // the previous snapshot intact.
+      throw new PresetLoadException(
+          "Failed to load presets from '" + sourcePath() + "': " + safeMessage(e), e);
     }
   }
 
@@ -158,6 +177,87 @@ public class PresetRegistry {
   // Internals
   // ------------------------------------------------------------------
 
+  private Map<String, PromptDefinition> loadPrompts(JsonObject root) {
+    var array = readArray(root, "prompts");
+    if (array == null || array.isEmpty()) return Map.of();
+
+    var definitions = new ArrayList<PromptDefinition>(array.size());
+    for (var index = 0; index < array.size(); index++) {
+      var element = array.get(index);
+      var location = "prompts[" + index + "]";
+      var id = readId(element);
+      try {
+        var definition = gson.fromJson(element, PromptDefinition.class);
+        if (definition == null) {
+          throw new NullPointerException("prompt definition deserialized to null");
+        }
+        definitions.add(definition);
+      } catch (RuntimeException e) {
+        throw malformed("prompt", id, location, e);
+      }
+    }
+    return buildIdMap(definitions, PromptDefinition::id, "prompt", this::logWarning);
+  }
+
+  private Map<String, PostCommand> loadPostCommands(JsonObject root) {
+    var array = readArray(root, "post_commands");
+    if (array == null || array.isEmpty()) return Map.of();
+
+    var definitions = new ArrayList<PostCommand>(array.size());
+    for (var index = 0; index < array.size(); index++) {
+      var element = array.get(index);
+      var location = "post_commands[" + index + "]";
+      var id = readId(element);
+      try {
+        var definition = gson.fromJson(element, PostCommand.class);
+        if (definition == null) {
+          throw new NullPointerException("post-command definition deserialized to null");
+        }
+        definitions.add(definition);
+      } catch (RuntimeException e) {
+        throw malformed("post-command", id, location, e);
+      }
+    }
+    return buildIdMap(definitions, PostCommand::id, "post-command", this::logWarning);
+  }
+
+  private JsonArray readArray(JsonObject root, String name) {
+    var element = root.get(name);
+    if (element == null || element.isJsonNull()) return null;
+    if (!element.isJsonArray()) {
+      throw malformed(name, "<unknown>", name,
+          new IllegalArgumentException("expected an array"));
+    }
+    return element.getAsJsonArray();
+  }
+
+  private static String readId(JsonElement element) {
+    if (element == null || !element.isJsonObject()) return "<unknown>";
+    try {
+      var id = element.getAsJsonObject().get("id");
+      return id != null && id.isJsonPrimitive() ? id.getAsString() : "<unknown>";
+    } catch (RuntimeException ignored) {
+      return "<unknown>";
+    }
+  }
+
+  private PresetLoadException malformed(String kind, String id, String location, Throwable cause) {
+    return new PresetLoadException(
+        "Invalid " + kind + " preset id '" + id + "' at '" + sourcePath() + "' ("
+            + location + "): " + safeMessage(cause),
+        cause);
+  }
+
+  private String sourcePath() {
+    return promptsFile.toPath().toAbsolutePath().normalize().toString();
+  }
+
+  private static String safeMessage(Throwable throwable) {
+    return throwable.getMessage() == null
+        ? throwable.getClass().getSimpleName()
+        : throwable.getMessage();
+  }
+
   private void ensureFileExists() throws IOException {
     if (promptsFile.exists()) return;
     if (plugin != null) {
@@ -197,7 +297,7 @@ public class PresetRegistry {
         warn.accept("Duplicate " + label + " id '" + id + "' (keeping the last definition)");
       }
     }
-    return Map.copyOf(map);
+    return Collections.unmodifiableMap(new LinkedHashMap<>(map));
   }
 
   private void logInfo(String msg) {

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/AnvilPromptScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/AnvilPromptScreen.java
@@ -3,6 +3,7 @@ package dev.cyr1en.promptpaper.screen;
 import dev.cyr1en.promptui.AnvilInputScreen;
 import dev.cyr1en.promptui.ScreenProvider;
 import dev.cyr1en.promptui.ScreenResult;
+import dev.cyr1en.promptui.InputScreen;
 import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.config.PromptConfig;
 import dev.cyr1en.promptui.ComponentUtil;
@@ -34,29 +35,68 @@ public class AnvilPromptScreen extends AbstractWrapperPromptScreen {
         var config = buildConfig(promptConfig);
 
         for (var provider : providers) {
+            InputScreen candidate = null;
             try {
                 plugin.getPluginLogger().debug("Attempting anvil provider: "
                         + provider.getClass().getSimpleName());
                 var nms = provider.createAnvil(plugin, player, displayText);
+                candidate = nms;
                 if (nms instanceof AnvilInputScreen anvilScreen) {
                     anvilScreen.configure(config);
                     anvilScreen.onResult(this::handleResult);
-                    anvilScreen.open();
                     this.wrapped = anvilScreen;
                     this.open = true;
+                    anvilScreen.onOpenFailure(failure -> handleAsyncProviderFailure(anvilScreen, failure));
+                    anvilScreen.open();
                     plugin.getPluginLogger().debug("Anvil provider succeeded: "
                             + provider.getClass().getSimpleName());
                     return;
                 }
             } catch (Throwable t) {
+                open = false;
+                if (candidate != null) {
+                    try {
+                        candidate.close();
+                    } catch (Throwable closeFailure) {
+                        plugin.getPluginLogger().debug("Anvil provider cleanup failed: "
+                                + closeFailure.getMessage());
+                    }
+                }
                 plugin.getPluginLogger().debug("Anvil provider "
                         + provider.getClass().getSimpleName() + " failed: " + t.getMessage());
             }
         }
         plugin.getPluginLogger().debug("All anvil providers failed, falling back to chat");
         wrapped = fallbackToChat();
-        wrapped.open();
         open = true;
+        try {
+            wrapped.open();
+        } catch (Throwable failure) {
+            open = false;
+            plugin.getPluginLogger().warn("Chat fallback for anvil prompt failed: "
+                    + failure.getMessage());
+        }
+    }
+
+    private void handleAsyncProviderFailure(AnvilInputScreen failed, Throwable failure) {
+        if (!open || wrapped != failed) return;
+        plugin.getPluginLogger().debug("Asynchronous anvil provider failed: " + failure.getMessage());
+        open = false;
+        try {
+            failed.close();
+        } catch (Throwable closeFailure) {
+            plugin.getPluginLogger().debug("Anvil provider cleanup failed: " + closeFailure.getMessage());
+        }
+        try {
+            var fallback = fallbackToChat();
+            wrapped = fallback;
+            open = true;
+            fallback.open();
+        } catch (Throwable fallbackFailure) {
+            open = false;
+            plugin.getPluginLogger().warn("Chat fallback for anvil prompt failed: "
+                    + fallbackFailure.getMessage());
+        }
     }
 
     private Map<String, String> buildConfig(PromptConfig cfg) {

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/DialogPromptScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/DialogPromptScreen.java
@@ -640,7 +640,7 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
         // Clamp bounds to prevent client crash
         maxLength = Math.max(1, Math.min(8192, maxLength));
         maxLines = Math.max(1, Math.min(8192, maxLines));
-        width = Math.max(1, Math.min(8192, width));
+        width = Math.max(1, Math.min(1024, width));
 
         return new DialogConstraints(
                 DialogInputKind.TEXT, "", 
@@ -973,7 +973,12 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
      * from the player scheduler.
      */
     private void onCancelFromView(DialogResponseView view) {
-        if (callback != null) callback.accept(ScreenResult.cancel());
+        player.getScheduler().run(plugin, scheduledTask -> {
+            if (!open) return;
+            open = false;
+            plugin.getPluginLogger().debug("Dialog cancelled (from view) for " + player.getName());
+            if (callback != null) callback.accept(ScreenResult.cancel());
+        }, null);
     }
 
     /**

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/DialogPromptScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/DialogPromptScreen.java
@@ -290,7 +290,7 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
 
         return Dialog.create(factory -> factory.empty()
                 .base(DialogBase.builder(title)
-                        .canCloseWithEscape(true)
+                        .canCloseWithEscape(false)
                         .build())
                 .type(io.papermc.paper.registry.data.dialog.type.DialogType.multiAction(List.copyOf(buttons), buildExitButton(), 1)));
     }
@@ -341,7 +341,7 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
 
         return Dialog.create(factory -> factory.empty()
                 .base(DialogBase.builder(title)
-                        .canCloseWithEscape(true)
+                        .canCloseWithEscape(false)
                         .body(List.of(DialogBody.plainMessage(notice)))
                         .inputs(List.of(input))
                         .build())
@@ -394,7 +394,7 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
 
         return Dialog.create(factory -> factory.empty()
                 .base(DialogBase.builder(title)
-                        .canCloseWithEscape(true)
+                        .canCloseWithEscape(false)
                         .body(bodies)
                         .inputs(inputs)
                         .build())
@@ -536,7 +536,7 @@ public class DialogPromptScreen implements InputScreen, DialogScreen {
 
         player.showDialog(Dialog.create(factory -> factory.empty()
                 .base(DialogBase.builder(title)
-                        .canCloseWithEscape(true)
+                        .canCloseWithEscape(false)
                         .body(body)
                         .inputs(inputs)
                         .build())

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
@@ -642,7 +642,16 @@ public class ScreenManager {
      * Cancels the active screen, timeout, and session for the player.
      */
     public void cancelAll(Player player) {
-        teardown(player, CancelReason.MANUAL, true, false);
+        cancelAll(player, false);
+    }
+
+    /**
+     * Cancels the active screen, timeout, and session for the player, optionally notifying
+     * players whose active prompt was cancelled.
+     */
+    public void cancelAll(Player player, boolean notifyCancelled) {
+        var hadActiveSession = engine.hasActiveSession(player);
+        teardown(player, CancelReason.MANUAL, true, notifyCancelled && hadActiveSession);
         plugin.getPluginLogger().debug("Cancelled all for " + player.getName());
     }
 

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
@@ -79,8 +79,13 @@ public class ScreenManager {
                 + " mode=" + mode + " permKey=" + permissionKey);
         var parsed = engine.intercept(target, commandLine);
         if (parsed.isEmpty()) {
-            plugin.getPluginLogger().debug("No prompts, dispatching directly");
-            dispatchDirect(target, commandLine, mode, permissionKey);
+            if (!engine.commandHasTagForm(commandLine)) {
+                plugin.getPluginLogger().debug("No prompts, dispatching directly");
+                dispatchDirect(target, commandLine, mode, permissionKey);
+            } else {
+                plugin.getPluginLogger().debug("Command had tag form but intercept rejected it "
+                        + "(missing preset, no permission, or active session); not dispatching");
+            }
             return;
         }
         if (mode != DispatchMode.NORMAL) {
@@ -198,6 +203,8 @@ public class ScreenManager {
                 + " cancelled=" + result.cancelled());
 
         if (result.cancelled()) {
+            dispatchModes.remove(player.getUniqueId());
+            attachmentKeys.remove(player.getUniqueId());
             engine.cancel(player, CancelReason.GUI_EXIT);
             player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.cancelled"));
             return;
@@ -233,6 +240,8 @@ public class ScreenManager {
         }
 
         if (isCancelKeyword) {
+            dispatchModes.remove(player.getUniqueId());
+            attachmentKeys.remove(player.getUniqueId());
             engine.cancel(player, CancelReason.MANUAL);
             player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.cancelled"));
             return;

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/ScreenManager.java
@@ -13,12 +13,15 @@ import dev.cyr1en.promptui.ComponentUtil;
 import dev.cyr1en.promptpaper.screen.dialog.AnswerEncoding;
 import dev.cyr1en.promptpaper.screen.dialog.DialogCompletionContext;
 import dev.cyr1en.promptpaper.screen.dialog.DialogInputKind;
+import dev.cyr1en.promptpaper.screen.playerui.PlayerUIScreen;
 import dev.cyr1en.promptpaper.util.CancellableTask;
 import dev.cyr1en.promptpaper.util.Scheduler;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import dev.cyr1en.promptcore.i18n.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -41,8 +44,11 @@ public class ScreenManager {
     private final Scheduler scheduler;
     private final Map<UUID, InputScreen> activeScreens;
     private final Map<UUID, CancellableTask> timeoutTasks;
+    private final Map<UUID, Long> timeoutTokens;
+    private final AtomicLong timeoutSequence;
     private final Map<UUID, DispatchMode> dispatchModes;
     private final Map<UUID, String> attachmentKeys;
+    private final Set<UUID> teardownInProgress;
 
     public ScreenManager(CommandPrompter plugin, PromptEngine engine, PromptFactory factory, Scheduler scheduler) {
         this.plugin = plugin;
@@ -51,8 +57,11 @@ public class ScreenManager {
         this.scheduler = scheduler;
         this.activeScreens = new ConcurrentHashMap<>();
         this.timeoutTasks = new ConcurrentHashMap<>();
+        this.timeoutTokens = new ConcurrentHashMap<>();
+        this.timeoutSequence = new AtomicLong();
         this.dispatchModes = new ConcurrentHashMap<>();
         this.attachmentKeys = new ConcurrentHashMap<>();
+        this.teardownInProgress = ConcurrentHashMap.newKeySet();
     }
 
     /**
@@ -67,7 +76,12 @@ public class ScreenManager {
         }
         plugin.getPluginLogger().debug("Starting session for " + player.getName()
                 + " with " + parsed.get().promptTags().size() + " prompts");
-        showNextPrompt(player);
+        var started = engine.runIfReloadNotInProgress(() -> showNextPrompt(player));
+        if (!started) {
+            engine.discard(player.getUniqueId());
+            engine.rejectIfReloading(player);
+            return;
+        }
     }
 
     /**
@@ -75,32 +89,65 @@ public class ScreenManager {
      * permission key for post-session command execution.
      */
     public void startDelegatedSession(Player target, String commandLine, DispatchMode mode, String permissionKey) {
-        plugin.getPluginLogger().debug("Delegated session: target=" + target.getName()
-                + " mode=" + mode + " permKey=" + permissionKey);
-        var parsed = engine.intercept(target, commandLine);
-        if (parsed.isEmpty()) {
-            if (!engine.commandHasTagForm(commandLine)) {
-                plugin.getPluginLogger().debug("No prompts, dispatching directly");
-                dispatchDirect(target, commandLine, mode, permissionKey);
-            } else {
-                plugin.getPluginLogger().debug("Command had tag form but intercept rejected it "
-                        + "(missing preset, no permission, or active session); not dispatching");
-            }
-            return;
+        var uuid = target.getUniqueId();
+        try {
+            var task = target.getScheduler().run(
+                    plugin,
+                    scheduledTask -> startDelegatedSessionOnPlayer(
+                            target, commandLine, mode, permissionKey),
+                    () -> discardState(uuid));
+            if (task == null) discardState(uuid);
+        } catch (Throwable t) {
+            plugin.getPluginLogger().err("Unable to schedule delegated session for " + uuid
+                    + ": " + t.getMessage());
+            discardState(uuid);
         }
-        if (mode != DispatchMode.NORMAL) {
-            dispatchModes.put(target.getUniqueId(), mode);
-            if (permissionKey != null) {
-                attachmentKeys.put(target.getUniqueId(), permissionKey);
+    }
+
+    private void startDelegatedSessionOnPlayer(
+            Player target, String commandLine, DispatchMode mode, String permissionKey) {
+        var uuid = target.getUniqueId();
+        try {
+            plugin.getPluginLogger().debug("Delegated session: target=" + target.getName()
+                    + " mode=" + mode + " permKey=" + permissionKey);
+            var normalized = commandLine.startsWith("/")
+                    ? commandLine.substring(1)
+                    : commandLine;
+            normalized = normalized.replace("%target_player%", target.getName());
+            var parsed = engine.intercept(target, normalized);
+            if (parsed.isEmpty()) {
+                if (!engine.commandHasTagForm(normalized)) {
+                    plugin.getPluginLogger().debug("No prompts, dispatching directly");
+                    dispatchDirect(target, normalized, mode, permissionKey);
+                } else {
+                    plugin.getPluginLogger().debug("Command had tag form but intercept rejected it "
+                            + "(missing preset, no permission, or active session); not dispatching");
+                }
+                return;
             }
+            var started = engine.runIfReloadNotInProgress(() -> {
+                if (mode != DispatchMode.NORMAL) {
+                    dispatchModes.put(uuid, mode);
+                    if (permissionKey != null) attachmentKeys.put(uuid, permissionKey);
+                }
+                showNextPrompt(target);
+            });
+            if (!started) {
+                engine.discard(uuid);
+                engine.rejectIfReloading(target);
+            }
+        } catch (Throwable t) {
+            plugin.getPluginLogger().err("Delegated session failed for " + uuid
+                    + ": " + t.getMessage());
+            discardState(uuid);
         }
-        showNextPrompt(target);
     }
 
     private void dispatchDirect(Player target, String commandLine, DispatchMode mode, String permissionKey) {
         switch (mode) {
             case CONSOLE -> dispatchAsConsole(target, commandLine);
-            case ATTACHMENT -> dispatchWithAttachment(target, commandLine, permissionKey);
+            case ATTACHMENT -> dispatchWithAttachment(
+                    target, commandLine, permissionKey, capturePermissionSnapshot(permissionKey));
             default -> dispatchAssembledCommand(target, commandLine);
         }
     }
@@ -132,27 +179,45 @@ public class ScreenManager {
      * screen via the router, and opens it for the player.
      */
     private void showPrompt(Player player, PromptTag tag) {
-        var displayText = resolvePlaceholders(player, tag.displayText());
-        var resolvedTag =
-            new PromptTag(
-                tag.rawTag(),
-                tag.key(),
-                tag.filter(),
-                displayText,
-                tag.sanitize(),
-                tag.validatorAlias(),
-                tag.type(),
-                tag.subTags(),
-                tag.preset(),
-                tag.title());
-        var context = buildCompletionContext(player, resolvedTag);
-        var screen = factory.createFromTag(player, resolvedTag, context);
-        plugin.getPluginLogger().debug("Showing prompt for " + player.getName()
-                + " key=" + tag.key() + " screen=" + screen.getClass().getSimpleName());
-        activeScreens.put(player.getUniqueId(), screen);
-        screen.onResult(result -> handleResult(player, result));
-        screen.open();
-        scheduleTimeout(player);
+        InputScreen screen = null;
+        var uuid = player.getUniqueId();
+        try {
+            var displayText = resolvePlaceholders(player, tag.displayText());
+            var resolvedTag =
+                new PromptTag(
+                    tag.rawTag(),
+                    tag.key(),
+                    tag.filter(),
+                    displayText,
+                    tag.sanitize(),
+                    tag.validatorAlias(),
+                    tag.type(),
+                    tag.subTags(),
+                    tag.preset(),
+                    tag.title());
+            var context = buildCompletionContext(player, resolvedTag);
+            screen = factory.createFromTag(player, resolvedTag, context);
+            plugin.getPluginLogger().debug("Showing prompt for " + player.getName()
+                    + " key=" + tag.key() + " screen=" + screen.getClass().getSimpleName());
+            activeScreens.put(uuid, screen);
+            screen.onResult(result -> handleResult(player, result));
+            screen.open();
+            scheduleTimeout(player);
+        } catch (Throwable e) {
+            if (screen != null) {
+                try {
+                    screen.close();
+                } catch (Exception ignored) {
+                    // The owning player may already be retired after an open failure.
+                }
+            }
+            discardState(uuid);
+            plugin.getPluginLogger().err("Unable to open prompt screen for " + uuid
+                    + ": " + e.getMessage());
+            if (e instanceof RuntimeException runtimeException) throw runtimeException;
+            if (e instanceof Error error) throw error;
+            throw new IllegalStateException("Prompt screen open failed", e);
+        }
     }
 
     /**
@@ -196,19 +261,18 @@ public class ScreenManager {
      * payloads, and either advances the session or dispatches the command.
      */
     private void handleResult(Player player, ScreenResult result) {
-        cancelTimeout(player);
-        activeScreens.remove(player.getUniqueId());
-
         plugin.getPluginLogger().debug("Screen result for " + player.getName()
                 + " cancelled=" + result.cancelled());
 
         if (result.cancelled()) {
-            dispatchModes.remove(player.getUniqueId());
-            attachmentKeys.remove(player.getUniqueId());
-            engine.cancel(player, CancelReason.GUI_EXIT);
-            player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.cancelled"));
+            cancelTimeout(player);
+            activeScreens.remove(player.getUniqueId());
+            teardown(player, CancelReason.GUI_EXIT, false, true);
             return;
         }
+
+        cancelTimeout(player);
+        activeScreens.remove(player.getUniqueId());
 
         var sessionOpt = engine.getSession(player);
         if (sessionOpt.isEmpty()) {
@@ -240,10 +304,7 @@ public class ScreenManager {
         }
 
         if (isCancelKeyword) {
-            dispatchModes.remove(player.getUniqueId());
-            attachmentKeys.remove(player.getUniqueId());
-            engine.cancel(player, CancelReason.MANUAL);
-            player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.cancelled"));
+            teardown(player, CancelReason.MANUAL, false, true);
             return;
         }
 
@@ -264,8 +325,10 @@ public class ScreenManager {
             var sessionResult = submitted.get();
             plugin.getPluginLogger().debug("Session complete, dispatching: "
                     + sessionResult.assembledCommand());
-            dispatchAssembledCommand(player, sessionResult.assembledCommand());
-            engine.dispatchPCMs(player, sessionResult, false);
+            var dispatchContext = dispatchAssembledCommand(
+                    player, sessionResult.assembledCommand());
+            sendCompletedCommand(player, sessionResult.assembledCommand());
+            engine.dispatchPCMs(player, sessionResult, false, dispatchContext);
         } else {
             plugin.getPluginLogger().debug("Answer accepted, showing next prompt");
             showNextPrompt(player);
@@ -299,8 +362,10 @@ public class ScreenManager {
             var sessionResult = submitted.get();
             plugin.getPluginLogger().debug("Session complete, dispatching: "
                     + sessionResult.assembledCommand());
-            dispatchAssembledCommand(player, sessionResult.assembledCommand());
-            engine.dispatchPCMs(player, sessionResult, false);
+            var dispatchContext = dispatchAssembledCommand(
+                    player, sessionResult.assembledCommand());
+            sendCompletedCommand(player, sessionResult.assembledCommand());
+            engine.dispatchPCMs(player, sessionResult, false, dispatchContext);
         } else {
             plugin.getPluginLogger().debug("Compound answers accepted, showing next prompt");
             showNextPrompt(player);
@@ -406,82 +471,159 @@ public class ScreenManager {
      * Dispatches the final command according to the player's active
      * dispatch mode (normal, console, or permission-attachment).
      */
-    private void dispatchAssembledCommand(Player player, String cmd) {
-        var mode = dispatchModes.remove(player.getUniqueId());
+    private PromptEngine.DispatchContext dispatchAssembledCommand(Player player, String cmd) {
+        var uuid = player.getUniqueId();
+        var mode = dispatchModes.remove(uuid);
         if (mode == null) mode = DispatchMode.NORMAL;
+        var key = attachmentKeys.remove(uuid);
+        var permissionSnapshot = mode == DispatchMode.ATTACHMENT
+                ? capturePermissionSnapshot(key)
+                : List.<String>of();
+        var dispatchContext = switch (mode) {
+            case CONSOLE -> new PromptEngine.DispatchContext(
+                    dev.cyr1en.promptpaper.preset.ExecuteAs.CONSOLE, null, false);
+            case ATTACHMENT -> new PromptEngine.DispatchContext(
+                    dev.cyr1en.promptpaper.preset.ExecuteAs.PLAYER,
+                    key,
+                    true,
+                    permissionSnapshot);
+            default -> PromptEngine.DispatchContext.player();
+        };
         plugin.getPluginLogger().debug("Dispatching for " + player.getName()
                 + " mode=" + mode + " cmd=" + cmd);
         switch (mode) {
             case CONSOLE -> dispatchAsConsole(player, cmd);
-            case ATTACHMENT -> {
-                var key = attachmentKeys.remove(player.getUniqueId());
-                dispatchWithAttachment(player, cmd, key);
-            }
+            case ATTACHMENT -> dispatchWithAttachment(player, cmd, key, permissionSnapshot);
             default -> {
                 var toExecute = cmd.startsWith("/") ? cmd.substring(1) : cmd;
-                player.getScheduler().run(plugin, scheduledTask -> {
-                    try {
-                        player.performCommand(toExecute);
-                    } catch (Exception e) {
-                        var msg = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-                        plugin.getPluginLogger().info("Command dispatch failed: " + msg);
-                        player.sendMessage(plugin.getConfigLoader().getI18n().get(
-                                "prompt.error.command_failed",
-                                player,
-                                Placeholder.of("message", msg != null ? msg : "")));
-                    }
-                }, null);
+                try {
+                    var task = player.getScheduler().run(plugin, scheduledTask -> {
+                        try {
+                            if (!player.performCommand(toExecute)) {
+                                sendCommandFailure(player, toExecute, "dispatch returned false");
+                            }
+                        } catch (Exception e) {
+                            var msg = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+                            sendCommandFailure(player, toExecute, msg);
+                        }
+                    }, null);
+                    if (task == null) sendCommandFailure(player, toExecute, "player retired");
+                } catch (Exception e) {
+                    sendCommandFailure(player, toExecute, e.getMessage());
+                }
             }
         }
+        return dispatchContext;
     }
 
     private void dispatchAsConsole(Player player, String cmd) {
         var toExecute = cmd.startsWith("/") ? cmd.substring(1) : cmd;
         plugin.getPluginLogger().debug("Dispatching as console: " + toExecute);
-        scheduler.runSync(() ->
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), toExecute));
+        scheduler.runSync(() -> {
+            try {
+                if (!Bukkit.dispatchCommand(Bukkit.getConsoleSender(), toExecute)) {
+                    sendCommandFailure(player, toExecute, "dispatch returned false");
+                }
+            } catch (Exception e) {
+                sendCommandFailure(player, toExecute, e.getMessage());
+            }
+        });
     }
 
     /**
      * Temporarily grants permissions, dispatches the command as the
      * player, then revokes the attachment.
      */
-    private void dispatchWithAttachment(Player player, String cmd, String permissionKey) {
-        if (permissionKey == null) {
-            plugin.getPluginLogger().debug("No permission key, falling back to console dispatch");
-            dispatchAsConsole(player, cmd);
+    private void dispatchWithAttachment(
+            Player player,
+            String cmd,
+            String permissionKey,
+            List<String> permissionSnapshot) {
+        if (permissionKey == null || permissionKey.isBlank()) {
+            plugin.getPluginLogger().err("Refusing attachment dispatch with an invalid permission key");
+            sendCommandFailure(player, cmd, "invalid permission attachment");
+            return;
+        }
+        if (permissionSnapshot == null || permissionSnapshot.isEmpty()) {
+            plugin.getPluginLogger().err("Refusing attachment dispatch for unknown permission key: "
+                    + permissionKey);
+            sendCommandFailure(player, cmd, "invalid permission attachment");
             return;
         }
         var config = plugin.getConfigLoader().getConfig();
-        var perms = config.getPermissionAttachment(permissionKey);
-        if (perms == null || perms.length == 0) {
-            plugin.getPluginLogger().debug("Permission key " + permissionKey
-                    + " has no permissions, falling back to console dispatch");
-            dispatchAsConsole(player, cmd);
-            return;
-        }
+        var permissions = permissionSnapshot.toArray(new String[0]);
         var toExecute = cmd.startsWith("/") ? cmd.substring(1) : cmd;
         plugin.getPluginLogger().debug("Dispatching with attachment key="
-                + permissionKey + " perms=" + java.util.Arrays.toString(perms));
-        player.getScheduler().run(plugin, scheduledTask -> {
-            var attachment = player.addAttachment(plugin);
-            if (attachment == null) {
-                plugin.getPluginLogger().err("Unable to create PermissionAttachment for " + player.getName());
-                return;
-            }
-            try {
-                for (var perm : perms) {
-                    attachment.setPermission(perm, true);
+                + permissionKey + " perms=" + java.util.Arrays.toString(permissions));
+        try {
+            var scheduled = player.getScheduler().run(plugin, scheduledTask -> {
+                var attachment = player.addAttachment(plugin);
+                if (attachment == null) {
+                    sendCommandFailure(player, toExecute, "unable to create permission attachment");
+                    return;
                 }
-                attachment.getPermissible().recalculatePermissions();
-                plugin.getPluginLogger().debug("Dispatching with attachment: player="
-                        + player.getName() + " perms=" + perms.length);
-                Bukkit.dispatchCommand(player, toExecute);
-            } finally {
-                player.removeAttachment(attachment);
-                plugin.getPluginLogger().debug("Attachment removed for " + player.getName());
+                var removed = new java.util.concurrent.atomic.AtomicBoolean();
+                Runnable remove = () -> {
+                    if (removed.compareAndSet(false, true)) {
+                        try {
+                            player.removeAttachment(attachment);
+                        } catch (Exception e) {
+                            plugin.getPluginLogger().debug("Unable to remove permission attachment");
+                        }
+                    }
+                };
+                boolean removalScheduled = false;
+                boolean failed = false;
+                try {
+                    for (var perm : permissions) attachment.setPermission(perm, true);
+                    attachment.getPermissible().recalculatePermissions();
+                    plugin.getPluginLogger().debug("Dispatching with attachment: player="
+                            + player.getName() + " perms=" + permissions.length);
+                    if (!Bukkit.dispatchCommand(player, toExecute)) {
+                        sendCommandFailure(player, toExecute, "dispatch returned false");
+                    }
+                } catch (Exception e) {
+                    failed = true;
+                    sendCommandFailure(player, toExecute, e.getMessage());
+                }
+                if (!failed && !removed.get() && config != null
+                        && config.permissionAttachmentTicks() > 0) {
+                    try {
+                        var removalTask = player.getScheduler().runDelayed(
+                                plugin,
+                                scheduledRemoval -> remove.run(),
+                                () -> {},
+                                config.permissionAttachmentTicks());
+                        removalScheduled = removalTask != null;
+                    } catch (Exception e) {
+                        plugin.getPluginLogger().debug("Attachment removal scheduling failed: "
+                                + e.getMessage());
+                    }
+                }
+                if (!removalScheduled) remove.run();
+            }, null);
+            if (scheduled == null) {
+                plugin.getPluginLogger().debug("Attachment dispatch skipped for retired player");
             }
-        }, null);
+        } catch (Exception e) {
+            sendCommandFailure(player, toExecute, e.getMessage());
+        }
+    }
+
+    private void sendCommandFailure(Player player, String command, String detail) {
+        var message = detail != null ? detail : "unknown error";
+        plugin.getPluginLogger().info("Command dispatch failed for '" + command + "': " + message);
+        try {
+            player.getScheduler().run(
+                    plugin,
+                    scheduledTask -> player.sendMessage(plugin.getConfigLoader().getI18n().get(
+                            "prompt.error.command_failed",
+                            player,
+                            Placeholder.of("message", message))),
+                    null);
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug("Unable to send command failure feedback: " + e.getMessage());
+        }
     }
 
     public boolean hasActiveScreen(Player player) {
@@ -500,13 +642,88 @@ public class ScreenManager {
      * Cancels the active screen, timeout, and session for the player.
      */
     public void cancelAll(Player player) {
-        cancelTimeout(player);
-        var screen = activeScreens.remove(player.getUniqueId());
-        if (screen != null) screen.close();
-        dispatchModes.remove(player.getUniqueId());
-        attachmentKeys.remove(player.getUniqueId());
-        engine.cancel(player, CancelReason.MANUAL);
+        teardown(player, CancelReason.MANUAL, true, false);
         plugin.getPluginLogger().debug("Cancelled all for " + player.getName());
+    }
+
+    /** Clears state after a player scheduler retires without invoking player APIs. */
+    public void discardState(UUID uuid) {
+        if (uuid == null) return;
+        cancelTimeout(uuid);
+        var screen = activeScreens.remove(uuid);
+        if (screen instanceof TitleWrapperScreen wrapper) {
+            wrapper.invalidateCallbacks();
+        } else if (screen instanceof PlayerUIScreen playerUIScreen) {
+            playerUIScreen.invalidateCallbacks();
+        }
+        dispatchModes.remove(uuid);
+        attachmentKeys.remove(uuid);
+        engine.discard(uuid);
+    }
+
+    private void teardown(
+            Player player, CancelReason reason, boolean closeScreen, boolean notifyCancelled) {
+        var uuid = player.getUniqueId();
+        if (!teardownInProgress.add(uuid)) return;
+        try {
+            cancelTimeout(uuid);
+            var screen = activeScreens.remove(uuid);
+            if (closeScreen && screen != null) {
+                try {
+                    screen.close();
+                } catch (Exception e) {
+                    plugin.getPluginLogger().debug("Unable to close screen for " + uuid + ": "
+                            + e.getMessage());
+                }
+            }
+            var dispatchContext = takeDispatchContext(uuid);
+            engine.cancel(player, reason, dispatchContext);
+            if (notifyCancelled && plugin.getConfigLoader().getConfig().showCancelled()) {
+                player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.cancelled"));
+            }
+        } finally {
+            teardownInProgress.remove(uuid);
+        }
+    }
+
+    private PromptEngine.DispatchContext takeDispatchContext(UUID uuid) {
+        var mode = dispatchModes.remove(uuid);
+        var key = attachmentKeys.remove(uuid);
+        if (mode == DispatchMode.CONSOLE) {
+            return new PromptEngine.DispatchContext(
+                    dev.cyr1en.promptpaper.preset.ExecuteAs.CONSOLE, null, false);
+        }
+        if (mode == DispatchMode.ATTACHMENT) {
+            var permissionSnapshot = capturePermissionSnapshot(key);
+            return new PromptEngine.DispatchContext(
+                    dev.cyr1en.promptpaper.preset.ExecuteAs.PLAYER,
+                    key,
+                    true,
+                    permissionSnapshot);
+        }
+        return PromptEngine.DispatchContext.player();
+    }
+
+    /** Captures the exact attachment list at the session completion/cancellation boundary. */
+    private List<String> capturePermissionSnapshot(String permissionKey) {
+        if (permissionKey == null || permissionKey.isBlank()) return List.of();
+        try {
+            var config = plugin.getConfigLoader().getConfig();
+            var permissions = config == null ? null : config.getPermissionAttachment(permissionKey);
+            if (permissions == null || permissions.length == 0) return List.of();
+            return List.copyOf(java.util.Arrays.asList(permissions));
+        } catch (Exception e) {
+            plugin.getPluginLogger().debug(
+                    "Unable to capture permission attachment key " + permissionKey + ": "
+                            + e.getMessage());
+            return List.of();
+        }
+    }
+
+    private void sendCompletedCommand(Player player, String command) {
+        if (plugin.getConfigLoader().getConfig().showCompleted()) {
+            player.sendMessage(net.kyori.adventure.text.Component.text(command));
+        }
     }
 
     /**
@@ -517,21 +734,53 @@ public class ScreenManager {
         cancelTimeout(player);
         var timeoutSecs = plugin.getConfigLoader().getConfig().promptTimeout();
         if (timeoutSecs <= 0) return;
+        var uuid = player.getUniqueId();
+        var token = timeoutSequence.incrementAndGet();
+        timeoutTokens.put(uuid, token);
         plugin.getPluginLogger().debug("Scheduling timeout for " + player.getName()
                 + " in " + timeoutSecs + "s");
-        var task = scheduler.runLater(() -> {
-            var session = engine.getSession(player);
-            if (session.isPresent() && session.get().isActive()) {
-                plugin.getPluginLogger().debug("Timeout triggered for " + player.getName());
-                cancelAll(player);
-                player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.timed_out"));
+        try {
+            var task = player.getScheduler().runDelayed(
+                    plugin,
+                    scheduledTask -> {
+                        if (!timeoutTokens.remove(uuid, token)) return;
+                        timeoutTasks.remove(uuid);
+                        var session = engine.getSession(player);
+                        if (session.isPresent() && session.get().isActive()) {
+                            plugin.getPluginLogger().debug("Timeout triggered for " + player.getName());
+                            teardown(player, CancelReason.MANUAL, true, false);
+                            if (plugin.getConfigLoader().getConfig().showCancelled()) {
+                                player.sendMessage(plugin.getConfigLoader().getI18n().get("prompt.timed_out"));
+                            }
+                        }
+                    },
+                    () -> discardTimeoutState(uuid, token),
+                    timeoutSecs * 20L);
+            if (task == null) {
+                discardTimeoutState(uuid, token);
+            } else if (timeoutTokens.get(uuid) == token) {
+                timeoutTasks.put(uuid, task::cancel);
+            } else {
+                task.cancel();
             }
-        }, timeoutSecs * 20L);
-        timeoutTasks.put(player.getUniqueId(), task);
+        } catch (Throwable t) {
+            discardTimeoutState(uuid, token);
+        }
     }
 
     private void cancelTimeout(Player player) {
-        var task = timeoutTasks.remove(player.getUniqueId());
+        cancelTimeout(player.getUniqueId());
+    }
+
+    private void cancelTimeout(UUID uuid) {
+        timeoutTokens.remove(uuid);
+        var task = timeoutTasks.remove(uuid);
         if (task != null) task.cancel();
+    }
+
+    private void discardTimeoutState(UUID uuid, long token) {
+        if (timeoutTokens.remove(uuid, token)) {
+            discardState(uuid);
+        }
     }
 }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/SignPromptScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/SignPromptScreen.java
@@ -3,6 +3,7 @@ package dev.cyr1en.promptpaper.screen;
 import dev.cyr1en.promptui.ScreenProvider;
 import dev.cyr1en.promptui.ScreenResult;
 import dev.cyr1en.promptui.SignInputScreen;
+import dev.cyr1en.promptui.InputScreen;
 import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.config.PromptConfig;
 import dev.cyr1en.promptui.ComponentUtil;
@@ -57,29 +58,68 @@ public class SignPromptScreen extends AbstractWrapperPromptScreen {
                 + " location=" + promptConfig.inputFieldLocation());
 
         for (var provider : providers) {
+            InputScreen candidate = null;
             try {
                 plugin.getPluginLogger().debug("Attempting sign provider: "
                         + provider.getClass().getSimpleName());
                 var nms = provider.createSign(plugin, player, arranged);
+                candidate = nms;
                 if (nms instanceof SignInputScreen signScreen) {
                     signScreen.configure(config);
                     signScreen.onResult(this::handleResult);
-                    signScreen.open();
                     this.wrapped = signScreen;
                     this.open = true;
+                    signScreen.onOpenFailure(failure -> handleAsyncProviderFailure(signScreen, failure));
+                    signScreen.open();
                     plugin.getPluginLogger().debug("Sign provider succeeded: "
                             + provider.getClass().getSimpleName());
                     return;
                 }
             } catch (Throwable t) {
+                open = false;
+                if (candidate != null) {
+                    try {
+                        candidate.close();
+                    } catch (Throwable closeFailure) {
+                        plugin.getPluginLogger().debug("Sign provider cleanup failed: "
+                                + closeFailure.getMessage());
+                    }
+                }
                 plugin.getPluginLogger().debug("Sign provider "
                         + provider.getClass().getSimpleName() + " failed: " + t.getMessage());
             }
         }
         plugin.getPluginLogger().debug("All sign providers failed, falling back to chat");
         wrapped = fallbackToChat();
-        wrapped.open();
         open = true;
+        try {
+            wrapped.open();
+        } catch (Throwable failure) {
+            open = false;
+            plugin.getPluginLogger().warn("Chat fallback for sign prompt failed: "
+                    + failure.getMessage());
+        }
+    }
+
+    private void handleAsyncProviderFailure(SignInputScreen failed, Throwable failure) {
+        if (!open || wrapped != failed) return;
+        plugin.getPluginLogger().debug("Asynchronous sign provider failed: " + failure.getMessage());
+        open = false;
+        try {
+            failed.close();
+        } catch (Throwable closeFailure) {
+            plugin.getPluginLogger().debug("Sign provider cleanup failed: " + closeFailure.getMessage());
+        }
+        try {
+            var fallback = fallbackToChat();
+            wrapped = fallback;
+            open = true;
+            fallback.open();
+        } catch (Throwable fallbackFailure) {
+            open = false;
+            plugin.getPluginLogger().warn("Chat fallback for sign prompt failed: "
+                    + fallbackFailure.getMessage());
+        }
     }
 
     private Map<String, String> buildConfig(PromptConfig cfg) {

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/TitleWrapperScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/TitleWrapperScreen.java
@@ -8,6 +8,7 @@ import dev.cyr1en.promptui.ComponentUtil;
 import dev.cyr1en.promptui.InputScreen;
 import dev.cyr1en.promptui.ScreenResult;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
@@ -93,13 +94,46 @@ public class TitleWrapperScreen implements InputScreen {
             + " ticks=" + ticks + " ticks, then opening " + delegate.getClass().getSimpleName());
 
     open = true;
-    pendingTask =
-        scheduler.runLater(
-            () -> {
+    var uuid = player.getUniqueId();
+    var task =
+        player.getScheduler().runDelayed(
+            plugin,
+            scheduledTask -> {
               pendingTask = null;
-              delegate.open();
+              try {
+                delegate.open();
+              } catch (Throwable e) {
+                open = false;
+                clearRetiredState(uuid);
+                plugin.getPluginLogger().err("Unable to open wrapped prompt screen: "
+                    + e.getMessage());
+              }
             },
+            () -> clearRetiredState(uuid),
             ticks);
+    if (task == null) {
+      pendingTask = null;
+      open = false;
+      clearRetiredState(uuid);
+    } else {
+      pendingTask = task::cancel;
+    }
+  }
+
+  private void clearRetiredState(UUID uuid) {
+    var screenManager = plugin.getScreenManager();
+    if (screenManager != null) screenManager.discardState(uuid);
+  }
+
+  void invalidateCallbacks() {
+    open = false;
+    if (pendingTask != null) {
+      pendingTask.cancel();
+      pendingTask = null;
+    }
+    if (delegate instanceof dev.cyr1en.promptpaper.screen.playerui.PlayerUIScreen playerUIScreen) {
+      playerUIScreen.invalidateCallbacks();
+    }
   }
 
   /** Cancels any pending delegate open, clears the title, and closes the delegate. */

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/HeadCache.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/HeadCache.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -128,20 +130,57 @@ public class HeadCache implements Listener {
         cache.clear();
         var players = new ArrayList<Player>(Bukkit.getOnlinePlayers());
         players.removeIf(this::isVanished);
-        processBatch(players, 0, callback);
+        processBatch(players, 0, callback, new AtomicBoolean());
     }
 
     private static final int BATCH_SIZE = 25;
 
-    private void processBatch(List<Player> players, int start, Runnable callback) {
+    private void processBatch(
+            List<Player> players, int start, Runnable callback, AtomicBoolean callbackCompleted) {
         int end = Math.min(start + BATCH_SIZE, players.size());
-        for (int i = start; i < end; i++) {
-            getHeadFor(players.get(i));
+        if (start >= end) {
+            if (callbackCompleted.compareAndSet(false, true)) callback.run();
+            return;
         }
+        var remaining = new AtomicInteger(end - start);
+        for (int i = start; i < end; i++) {
+            Player p = players.get(i);
+            var playerCompleted = new AtomicBoolean();
+            Runnable completePlayer = () -> {
+                if (playerCompleted.compareAndSet(false, true)
+                        && remaining.decrementAndGet() == 0) {
+                    continueBatch(players, end, callback, callbackCompleted);
+                }
+            };
+            try {
+                var task = p.getScheduler().run(
+                        plugin,
+                        scheduledTask -> {
+                            try {
+                                getHeadFor(p);
+                            } finally {
+                                completePlayer.run();
+                            }
+                        },
+                        completePlayer);
+                if (task == null) completePlayer.run();
+            } catch (Throwable t) {
+                completePlayer.run();
+            }
+        }
+    }
+
+    private void continueBatch(
+            List<Player> players, int end, Runnable callback, AtomicBoolean callbackCompleted) {
         if (end < players.size()) {
-            scheduler.runLater(() -> processBatch(players, end, callback), 1);
+            try {
+                scheduler.runLater(
+                        () -> processBatch(players, end, callback, callbackCompleted), 1);
+            } catch (Throwable t) {
+                if (callbackCompleted.compareAndSet(false, true)) callback.run();
+            }
         } else {
-            callback.run();
+            if (callbackCompleted.compareAndSet(false, true)) callback.run();
         }
     }
 
@@ -158,7 +197,17 @@ public class HeadCache implements Listener {
         if (vanished) return;
         var delay = plugin.getConfigLoader().getPromptConfig().cacheDelay();
         if (delay > 0) {
-            scheduler.runLater(() -> getHeadFor(player), delay);
+            try {
+                var task = player.getScheduler().runDelayed(
+                        plugin, scheduledTask -> getHeadFor(player), null, delay);
+                if (task == null) {
+                    plugin.getPluginLogger().debug("Head-cache join task retired for "
+                            + player.getUniqueId());
+                }
+            } catch (Exception e) {
+                plugin.getPluginLogger().debug("Unable to schedule head-cache join task for "
+                        + player.getUniqueId() + ": " + e.getMessage());
+            }
         } else {
             getHeadFor(player);
         }

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/PlayerUIScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/PlayerUIScreen.java
@@ -17,6 +17,8 @@ import java.util.function.Consumer;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -36,7 +38,8 @@ public class PlayerUIScreen implements InputScreen {
     private PaginatedPane headPane;
     private List<ItemStack> currentHeads;
     private boolean open;
-    private org.bukkit.event.Listener searchListener;
+    private Listener searchListener;
+    private Listener quitListener;
 
     public PlayerUIScreen(CommandPrompter plugin, Player player, PromptTag tag, dev.cyr1en.promptpaper.preset.PlayerUiPrompt puiPrompt) {
         this.plugin = plugin;
@@ -119,6 +122,7 @@ public class PlayerUIScreen implements InputScreen {
         gui.setOnClose(event -> {
             if (open) {
                 open = false;
+                unregisterListeners();
                 if (callback != null) {
                     callback.accept(ScreenResult.cancel());
                 }
@@ -258,6 +262,10 @@ public class PlayerUIScreen implements InputScreen {
         player.closeInventory();
         player.sendMessage(plugin.getConfigLoader().getI18n().get("player_ui.search_instruction"));
 
+        if (searchListener != null) {
+            HandlerList.unregisterAll(searchListener);
+            searchListener = null;
+        }
         var listener = new org.bukkit.event.Listener() {
             @org.bukkit.event.EventHandler(priority = org.bukkit.event.EventPriority.LOWEST)
             public void onChat(org.bukkit.event.player.AsyncPlayerChatEvent event) {
@@ -268,7 +276,7 @@ public class PlayerUIScreen implements InputScreen {
                 player.getScheduler().run(plugin, st -> {
                     plugin.getPluginLogger().debug("PlayerUI search: term=" + search
                             + " pre-filter=" + currentHeads.size());
-                    org.bukkit.event.HandlerList.unregisterAll(this);
+                    HandlerList.unregisterAll(this);
                     searchListener = null;
                     var filtered = currentHeads.stream()
                             .filter(item -> {
@@ -288,17 +296,30 @@ public class PlayerUIScreen implements InputScreen {
     }
 
     private void registerQuitListener() {
-        Bukkit.getPluginManager().registerEvents(new org.bukkit.event.Listener() {
+        if (quitListener != null) {
+            HandlerList.unregisterAll(quitListener);
+        }
+        var listener = new Listener() {
             @org.bukkit.event.EventHandler
             public void onQuit(org.bukkit.event.player.PlayerQuitEvent event) {
                 if (event.getPlayer().getUniqueId().equals(player.getUniqueId())) {
-                    if (searchListener != null) {
-                        org.bukkit.event.HandlerList.unregisterAll(searchListener);
-                        searchListener = null;
-                    }
+                    unregisterListeners();
                 }
             }
-        }, plugin);
+        };
+        quitListener = listener;
+        Bukkit.getPluginManager().registerEvents(listener, plugin);
+    }
+
+    private void unregisterListeners() {
+        if (searchListener != null) {
+            HandlerList.unregisterAll(searchListener);
+            searchListener = null;
+        }
+        if (quitListener != null) {
+            HandlerList.unregisterAll(quitListener);
+            quitListener = null;
+        }
     }
 
     private GuiItem buildItem(String materialName, int cmd, String displayName,
@@ -317,14 +338,14 @@ public class PlayerUIScreen implements InputScreen {
 
     @Override
     public void close() {
-        if (!open && gui == null) return;
+        if (!open && gui == null) {
+            unregisterListeners();
+            return;
+        }
         open = false;
         plugin.getPluginLogger().debug("PlayerUI closing for " + player.getName()
                 + " searchActive=" + (searchListener != null));
-        if (searchListener != null) {
-            org.bukkit.event.HandlerList.unregisterAll(searchListener);
-            searchListener = null;
-        }
+        unregisterListeners();
         if (gui != null) {
             player.closeInventory();
             gui = null;

--- a/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/PlayerUIScreen.java
+++ b/prompt-paper/src/main/java/dev/cyr1en/promptpaper/screen/playerui/PlayerUIScreen.java
@@ -13,6 +13,7 @@ import dev.cyr1en.promptpaper.config.PromptConfig;
 import dev.cyr1en.promptui.ComponentUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -37,6 +38,7 @@ public class PlayerUIScreen implements InputScreen {
     private ChestGui gui;
     private PaginatedPane headPane;
     private List<ItemStack> currentHeads;
+    private final AtomicLong lifecycleToken = new AtomicLong();
     private boolean open;
     private Listener searchListener;
     private Listener quitListener;
@@ -46,7 +48,7 @@ public class PlayerUIScreen implements InputScreen {
         this.player = player;
         this.tag = tag;
         this.puiPrompt = puiPrompt;
-        this.currentHeads = new ArrayList<>();
+        this.currentHeads = null;
     }
 
     /**
@@ -55,6 +57,8 @@ public class PlayerUIScreen implements InputScreen {
      */
     @Override
     public void open() {
+        var token = lifecycleToken.get();
+        var uuid = player.getUniqueId();
         var headCache = plugin.getHeadCache();
         int onlineCount = (int) Bukkit.getOnlinePlayers().stream()
                 .filter(p -> !headCache.isVanished(p))
@@ -63,14 +67,33 @@ public class PlayerUIScreen implements InputScreen {
             plugin.getPluginLogger().debug("PlayerUI cache mismatch: cache="
                     + headCache.size() + " online=" + onlineCount
                     + " — rebuilding before open");
-            headCache.buildCache(this::openInternal);
+            headCache.buildCache(() -> {
+                if (lifecycleToken.get() != token) return;
+                try {
+                    var task = player.getScheduler().run(
+                            plugin,
+                            scheduledTask -> {
+                                if (lifecycleToken.get() == token) openInternal(token);
+                            },
+                            () -> {});
+                    if (task == null) discardScreenState(uuid);
+                } catch (Exception e) {
+                    plugin.getPluginLogger().debug("PlayerUI cache completion was retired for " + uuid);
+                    discardScreenState(uuid);
+                }
+            });
             return;
         }
-        openInternal();
+        openInternal(token);
     }
 
     private void openInternal() {
-        if (currentHeads.isEmpty())
+        openInternal(lifecycleToken.get());
+    }
+
+    private void openInternal(long token) {
+        if (lifecycleToken.get() != token) return;
+        if (currentHeads == null)
             currentHeads = getFilteredHeads();
 
         registerQuitListener();
@@ -257,6 +280,8 @@ public class PlayerUIScreen implements InputScreen {
      * to use as a search term, then reopens with filtered results.
      */
     private void startSearch() {
+        var token = lifecycleToken.get();
+        var playerUuid = player.getUniqueId();
         plugin.getPluginLogger().debug("PlayerUI search started for " + player.getName());
         open = false;
         player.closeInventory();
@@ -269,26 +294,33 @@ public class PlayerUIScreen implements InputScreen {
         var listener = new org.bukkit.event.Listener() {
             @org.bukkit.event.EventHandler(priority = org.bukkit.event.EventPriority.LOWEST)
             public void onChat(org.bukkit.event.player.AsyncPlayerChatEvent event) {
-                if (!event.getPlayer().getUniqueId().equals(player.getUniqueId())) return;
+                if (!event.getPlayer().getUniqueId().equals(playerUuid)) return;
+                if (lifecycleToken.get() != token) return;
                 event.setCancelled(true);
                 var search = event.getMessage();
 
-                player.getScheduler().run(plugin, st -> {
-                    plugin.getPluginLogger().debug("PlayerUI search: term=" + search
-                            + " pre-filter=" + currentHeads.size());
-                    HandlerList.unregisterAll(this);
-                    searchListener = null;
-                    var filtered = currentHeads.stream()
-                            .filter(item -> {
-                                var meta = item.getItemMeta();
-                                if (meta == null) return false;
-                                var name = meta.getDisplayName();
-                                return name.toLowerCase().contains(search.toLowerCase());
-                            })
-                            .toList();
-                    currentHeads = new ArrayList<>(filtered);
-                    open();
-                }, null);
+                try {
+                    var task = player.getScheduler().run(plugin, st -> {
+                        if (lifecycleToken.get() != token || currentHeads == null) return;
+                        plugin.getPluginLogger().debug("PlayerUI search: term=" + search
+                                + " pre-filter=" + currentHeads.size());
+                        HandlerList.unregisterAll(this);
+                        searchListener = null;
+                        var filtered = currentHeads.stream()
+                                .filter(item -> {
+                                    var meta = item.getItemMeta();
+                                    if (meta == null) return false;
+                                    var name = meta.getDisplayName();
+                                    return name.toLowerCase().contains(search.toLowerCase());
+                                })
+                                .toList();
+                        currentHeads = new ArrayList<>(filtered);
+                        open();
+                    }, () -> {});
+                    if (task == null) discardScreenState(playerUuid);
+                } catch (Exception e) {
+                    discardScreenState(playerUuid);
+                }
             }
         };
         this.searchListener = listener;
@@ -303,6 +335,7 @@ public class PlayerUIScreen implements InputScreen {
             @org.bukkit.event.EventHandler
             public void onQuit(org.bukkit.event.player.PlayerQuitEvent event) {
                 if (event.getPlayer().getUniqueId().equals(player.getUniqueId())) {
+                    invalidateCallbacks();
                     unregisterListeners();
                 }
             }
@@ -338,10 +371,7 @@ public class PlayerUIScreen implements InputScreen {
 
     @Override
     public void close() {
-        if (!open && gui == null) {
-            unregisterListeners();
-            return;
-        }
+        lifecycleToken.incrementAndGet();
         open = false;
         plugin.getPluginLogger().debug("PlayerUI closing for " + player.getName()
                 + " searchActive=" + (searchListener != null));
@@ -350,6 +380,16 @@ public class PlayerUIScreen implements InputScreen {
             player.closeInventory();
             gui = null;
         }
+    }
+
+    public void invalidateCallbacks() {
+        lifecycleToken.incrementAndGet();
+        open = false;
+    }
+
+    private void discardScreenState(java.util.UUID uuid) {
+        var manager = plugin.getScreenManager();
+        if (manager != null) manager.discardState(uuid);
     }
 
     @Override

--- a/prompt-paper/src/main/resources/META-INF/services/dev.cyr1en.promptui.ScreenProvider
+++ b/prompt-paper/src/main/resources/META-INF/services/dev.cyr1en.promptui.ScreenProvider
@@ -1,0 +1,2 @@
+dev.cyr1en.promptui.v26_1.V26_1ScreenProvider
+dev.cyr1en.promptui.v26_2.V26_2ScreenProvider

--- a/prompt-paper/src/main/resources/paper-plugin.yml
+++ b/prompt-paper/src/main/resources/paper-plugin.yml
@@ -21,6 +21,13 @@ dependencies:
 permissions:
   promptpaper.admin:
     description: Master permission for CommandPrompter commands
+    children:
+      promptpaper.reload: true
+      promptpaper.cancel: true
+      promptpaper.version: true
+      promptpaper.use: true
+      promptpaper.consoledelegate: true
+      promptpaper.playerdelegate: true
   promptpaper.reload:
     description: Allows using /commandprompter reload
   promptpaper.cancel:

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
@@ -100,7 +100,7 @@ public class MockBukkitTest {
         when(i18n.get(eq("command.reload.failed"), any(Placeholder[].class)))
                 .thenReturn(Component.text("Failed to reload."));
         when(i18n.get(eq("command.version"), any(Placeholder[].class)))
-                .thenReturn(Component.text("CommandPrompterPaper v3.1.0-test"));
+                .thenReturn(Component.text("CommandPrompterPaper v3.1.1-test"));
         when(i18n.get(eq("dialog.too_many_options"), any(Placeholder[].class)))
                 .thenReturn(Component.text("Too many options, enter argument manually."));
 
@@ -112,9 +112,9 @@ public class MockBukkitTest {
         when(i18n.get(eq("command.delegate.unknown_permission"), isNull(), any(Placeholder[].class)))
                 .thenReturn(Component.text("Unknown permission key."));
         when(i18n.get(eq("command.version"), any(Player.class), any(Placeholder[].class)))
-                .thenReturn(Component.text("CommandPrompterPaper v3.1.0-test"));
+                .thenReturn(Component.text("CommandPrompterPaper v3.1.1-test"));
         when(i18n.get(eq("command.version"), isNull(), any(Placeholder[].class)))
-                .thenReturn(Component.text("CommandPrompterPaper v3.1.0-test"));
+                .thenReturn(Component.text("CommandPrompterPaper v3.1.1-test"));
         when(i18n.get(eq("dialog.no_options"), any(Player.class)))
                 .thenReturn(Component.text("No options available, enter argument manually."));
         when(i18n.get(eq("dialog.too_many_options"), any(Player.class), any(Placeholder[].class)))

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
@@ -14,6 +14,7 @@ import dev.cyr1en.promptpaper.config.sub.DialogConfig;
 import dev.cyr1en.promptpaper.hook.HookContainer;
 import dev.cyr1en.promptpaper.i18n.PaperI18n;
 import dev.cyr1en.promptpaper.testutil.MockScheduler;
+import dev.cyr1en.promptpaper.testutil.TestPlayerMock;
 import dev.cyr1en.promptpaper.util.PluginLogger;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
@@ -137,11 +138,13 @@ public class MockBukkitTest {
     }
 
     protected PlayerMock createPlayer() {
-        return server.addPlayer();
+        return createPlayer("Player");
     }
 
     protected PlayerMock createPlayer(String name) {
-        return server.addPlayer(name);
+        var player = new TestPlayerMock(server, name);
+        server.addPlayer(player);
+        return player;
     }
 
     protected void performTicks(long ticks) {

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
@@ -7,9 +7,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import dev.cyr1en.promptcore.CancelReason;
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import dev.cyr1en.promptpaper.engine.PromptEngine;
+import dev.cyr1en.promptpaper.screen.ScreenManager;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,11 +20,14 @@ class CancelCommandTest extends MockBukkitTest {
 
     private CancelCommand cmd;
     private PromptEngine engine;
+    private ScreenManager screenManager;
 
     @BeforeEach
     void setUp() {
         engine = mock(PromptEngine.class);
         when(plugin.getEngine()).thenReturn(engine);
+        screenManager = mock(ScreenManager.class);
+        when(plugin.getScreenManager()).thenReturn(screenManager);
         cmd = new CancelCommand(plugin);
     }
 
@@ -33,7 +36,7 @@ class CancelCommandTest extends MockBukkitTest {
         var sender = mock(CommandSender.class);
         cmd.executeCancel(sender);
         verify(sender, times(1)).sendMessage(any(Component.class));
-        verify(engine, never()).cancel(any(), any());
+        verify(screenManager, never()).cancelAll(any());
     }
 
     @Test
@@ -41,7 +44,7 @@ class CancelCommandTest extends MockBukkitTest {
         PlayerMock player = createPlayer("Alice");
         when(engine.hasActiveSession(player)).thenReturn(false);
         cmd.executeCancel(player);
-        verify(engine, never()).cancel(any(), any());
+        verify(screenManager, never()).cancelAll(any());
     }
 
     @Test
@@ -49,7 +52,7 @@ class CancelCommandTest extends MockBukkitTest {
         PlayerMock player = createPlayer("Bob");
         when(engine.hasActiveSession(player)).thenReturn(true);
         cmd.executeCancel(player);
-        verify(engine, times(1)).cancel(player, CancelReason.MANUAL);
+        verify(screenManager, times(1)).cancelAll(player);
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ConsoleDelegateCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ConsoleDelegateCommandTest.java
@@ -43,7 +43,7 @@ class ConsoleDelegateCommandTest extends MockBukkitTest {
         PlayerMock target = createPlayer("Alice");
         cmd.startSession("Console", target, "msg %target_player% hi");
         verify(screenManager, times(1)).startDelegatedSession(
-                target, "msg Alice hi", DispatchMode.CONSOLE, null);
+                target, "msg %target_player% hi", DispatchMode.CONSOLE, null);
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/PlayerDelegateCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/PlayerDelegateCommandTest.java
@@ -67,7 +67,7 @@ class PlayerDelegateCommandTest extends MockBukkitTest {
 
         assertEquals(com.mojang.brigadier.Command.SINGLE_SUCCESS, result);
         verify(screenManager, times(1)).startDelegatedSession(
-                target, "msg Alice hi", DispatchMode.ATTACHMENT, "GAMEMODE");
+                target, "msg %target_player% hi", DispatchMode.ATTACHMENT, "GAMEMODE");
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/PromptCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/PromptCommandTest.java
@@ -38,6 +38,15 @@ class PromptCommandTest extends MockBukkitTest {
     }
 
     @Test
+    void allowedPassesWithMasterAdminPermission() {
+        var sender = mock(CommandSender.class);
+        when(sender.hasPermission("promptpaper.admin")).thenReturn(true);
+        when(sender.hasPermission("promptpaper.test")).thenReturn(false);
+        var cmd = new TestCommand(plugin, "x", "promptpaper.test", null, "desc", List.of());
+        assertTrue(cmd.allowed(sender));
+    }
+
+    @Test
     void allowedFailsWhenSenderFilterMismatched() {
         var sender = mock(CommandSender.class);
         var cmd = new TestCommand(plugin, "x", null, ConsoleCommandSender.class, "desc", List.of());

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ReloadCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ReloadCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -18,6 +19,11 @@ import dev.cyr1en.promptpaper.i18n.PaperI18n;
 import dev.cyr1en.promptpaper.preset.PresetRegistry;
 import dev.cyr1en.promptpaper.screen.ScreenManager;
 import net.kyori.adventure.text.Component;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +55,7 @@ class ReloadCommandTest extends MockBukkitTest {
         when(plugin.getScreenManager()).thenReturn(screenManager);
         when(plugin.getConfigLoader()).thenReturn(loader);
         when(plugin.getPresetRegistry()).thenReturn(registry);
+        when(engine.beginReload()).thenReturn(true);
 
         cmd = new ReloadCommand(plugin);
     }
@@ -66,6 +73,7 @@ class ReloadCommandTest extends MockBukkitTest {
         verify(engine, times(1)).reloadParser();
         verify(registry, times(1)).reload();
         verify(sender, times(1)).sendMessage(any(Component.class));
+        verify(engine, times(1)).endReload();
     }
 
     @Test
@@ -79,10 +87,11 @@ class ReloadCommandTest extends MockBukkitTest {
         cmd.executeReload(sender);
 
         verify(screenManager, times(1)).cancelAll(player);
-        verify(engine, times(1)).cancelAll();
+        verify(engine, times(1)).discardAll();
         verify(loader, times(1)).reload();
         verify(engine, times(1)).reloadParser();
         verify(registry, times(1)).reload();
+        verify(engine, times(1)).endReload();
     }
 
     @Test
@@ -96,6 +105,7 @@ class ReloadCommandTest extends MockBukkitTest {
 
         verify(sender, times(1)).sendMessage(any(Component.class));
         verify(engine, never()).reloadParser();
+        verify(engine, times(1)).endReload();
     }
 
     @Test
@@ -113,6 +123,7 @@ class ReloadCommandTest extends MockBukkitTest {
         verify(loader, times(1)).reload();
         verify(engine, times(1)).reloadParser();
         verify(sender, times(1)).sendMessage(any(Component.class));
+        verify(engine, times(1)).endReload();
     }
 
     @Test
@@ -133,6 +144,49 @@ class ReloadCommandTest extends MockBukkitTest {
         verify(registry, times(1)).reload();
         // Exactly one error message is sent; success message must not be sent.
         verify(sender, times(1)).sendMessage(any(Component.class));
+        verify(engine, times(1)).endReload();
+    }
+
+    @Test
+    void reloadRequestIsRejectedWhenAnotherBarrierIsActive() {
+        when(engine.beginReload()).thenReturn(false);
+        when(engine.isReloadInProgress()).thenReturn(true);
+        var sender = mock(CommandSender.class);
+        when(sender.getName()).thenReturn("TestUser");
+
+        cmd.executeReload(sender);
+
+        verify(loader, never()).reload();
+        verify(engine, never()).endReload();
+        verify(sender, times(1)).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void realReloadGateClearsAfterFailure() {
+        var realEngine = new PromptEngine(plugin, scheduler);
+        when(plugin.getEngine()).thenReturn(realEngine);
+        when(plugin.getScreenManager()).thenReturn(null);
+        doThrow(new RuntimeException("boom")).when(loader).reload();
+        var sender = mock(CommandSender.class);
+        when(sender.getName()).thenReturn("TestUser");
+
+        cmd.executeReload(sender);
+
+        assertFalse(realEngine.isReloadInProgress());
+    }
+
+    @Test
+    void realReloadGateClearsAfterSuccess() {
+        var realEngine = new PromptEngine(plugin, scheduler);
+        when(plugin.getEngine()).thenReturn(realEngine);
+        when(plugin.getScreenManager()).thenReturn(null);
+        doNothing().when(loader).reload();
+        var sender = mock(CommandSender.class);
+        when(sender.getName()).thenReturn("TestUser");
+
+        cmd.executeReload(sender);
+
+        assertFalse(realEngine.isReloadInProgress());
     }
 
     @Test
@@ -149,5 +203,41 @@ class ReloadCommandTest extends MockBukkitTest {
         var withPerm = mock(CommandSender.class);
         when(withPerm.hasPermission("promptpaper.reload")).thenReturn(true);
         assertTrue(cmd.allowed(withPerm));
+    }
+
+    @Test
+    void nonregionalFeedbackUsesGlobalScheduler() {
+        var globalScheduler = mock(dev.cyr1en.promptpaper.util.Scheduler.class);
+        when(plugin.getScheduler()).thenReturn(globalScheduler);
+        var sender = mock(CommandSender.class);
+        var message = Component.text("reload result");
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(globalScheduler).runSync(any(Runnable.class));
+
+        cmd.sendResult(sender, null, message);
+
+        verify(globalScheduler, times(1)).runSync(any(Runnable.class));
+        verify(sender, times(1)).sendMessage(message);
+    }
+
+    @Test
+    void blockFeedbackUsesTheBlockRegionScheduler() {
+        var regionScheduler = mock(RegionScheduler.class);
+        var sender = mock(BlockCommandSender.class);
+        var location = new Location(null, 10, 64, 10);
+        var message = Component.text("reload result");
+        when(regionScheduler.run(eq(plugin), eq(location), any()))
+                .thenReturn(mock(ScheduledTask.class));
+
+        try (var mockedBukkit = org.mockito.Mockito.mockStatic(Bukkit.class)) {
+            mockedBukkit.when(Bukkit::getRegionScheduler).thenReturn(regionScheduler);
+
+            cmd.sendResult(sender, location, message);
+        }
+
+        verify(regionScheduler, times(1)).run(eq(plugin), eq(location), any());
+        verify(sender, never()).sendMessage(message);
     }
 }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ReloadCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/ReloadCommandTest.java
@@ -86,7 +86,7 @@ class ReloadCommandTest extends MockBukkitTest {
 
         cmd.executeReload(sender);
 
-        verify(screenManager, times(1)).cancelAll(player);
+        verify(screenManager, times(1)).cancelAll(player, true);
         verify(engine, times(1)).discardAll();
         verify(loader, times(1)).reload();
         verify(engine, times(1)).reloadParser();

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/VersionCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/VersionCommandTest.java
@@ -20,7 +20,7 @@ class VersionCommandTest extends MockBukkitTest {
     @BeforeEach
     void setUp() {
         var meta = mock(PluginMeta.class);
-        when(meta.getVersion()).thenReturn("3.1.0-test");
+        when(meta.getVersion()).thenReturn("3.1.1-test");
         when(plugin.getPluginMeta()).thenReturn(meta);
 
         cmd = new VersionCommand(plugin);

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/config/ConfigValidationTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/config/ConfigValidationTest.java
@@ -1,0 +1,149 @@
+package dev.cyr1en.promptpaper.config;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.cyr1en.promptpaper.MockBukkitTest;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConfigValidationTest extends MockBukkitTest {
+
+  @Test
+  void playerUiSizeMustBeAValidChestSize() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PromptConfigTestData().copy(Map.of("playerUISize", 20)));
+  }
+
+  @Test
+  void dialogNumberDefaultsRejectInvalidRanges() {
+    var data = new PromptConfigTestData();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> data.copy(Map.of("dialogNumberMin", Float.NaN)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> data.copy(Map.of("dialogNumberMin", 10.0f, "dialogNumberMax", 10.0f)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> data.copy(Map.of("dialogNumberStep", 0.0f)));
+  }
+
+  @Test
+  void allConfiguredValidatorRegexesAreCompiledDuringConstruction() {
+    var data = new PromptConfigTestData();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> data.copy(Map.of("intSampleRegex", "[")));
+  }
+
+  /** Reflection helper keeps this test independent of the very wide flat config record. */
+  private static final class PromptConfigTestData {
+    private final PromptConfig base;
+
+    private PromptConfigTestData() {
+      base =
+          new PromptConfig(
+              org.mockito.Mockito.mock(dev.cyr1en.promptcore.config.YamlDocument.class),
+              "%s",
+              0,
+              54,
+              256,
+              1,
+              "Feather",
+              0,
+              3,
+              "Previous",
+              "Feather",
+              0,
+              7,
+              "Next",
+              "Barrier",
+              0,
+              5,
+              "Cancel",
+              "Name_Tag",
+              0,
+              9,
+              "Search",
+              "Player Search",
+              "PAPER",
+              0,
+              "Enter Player Name",
+              false,
+              "No players",
+              "World %s",
+              "Radial %s",
+              true,
+              "",
+              "",
+              false,
+              "Paper",
+              false,
+              0,
+              false,
+              "Paper",
+              false,
+              0,
+              false,
+              "Barrier",
+              false,
+              0,
+              false,
+              "Cancel",
+              true,
+              "Cancel",
+              "Hover",
+              "DEFAULT",
+              "bottom",
+              "OAK_SIGN",
+              "is",
+              "^\\d+",
+              "bad int",
+              "ss",
+              "[A-Za-z ]+",
+              "bad string",
+              "Prompt",
+              "Confirm",
+              "Confirm tooltip",
+              "Cancel",
+              "Cancel tooltip",
+              256,
+              false,
+              4,
+              200,
+              "",
+              0.0f,
+              100.0f,
+              1.0f,
+              5);
+    }
+
+    private PromptConfig copy(Map<String, Object> changes) {
+      try {
+        var components = PromptConfig.class.getRecordComponents();
+        var arguments = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+          arguments[i] = components[i].getAccessor().invoke(base);
+        }
+        var byName = new HashMap<String, Integer>();
+        for (int i = 0; i < components.length; i++) byName.put(components[i].getName(), i);
+        for (var entry : changes.entrySet()) arguments[byName.get(entry.getKey())] = entry.getValue();
+        Class<?>[] types =
+            java.util.Arrays.stream(components)
+                .map(java.lang.reflect.RecordComponent::getType)
+                .toArray(Class<?>[]::new);
+        Constructor<PromptConfig> constructor = PromptConfig.class.getDeclaredConstructor(types);
+        return constructor.newInstance(arguments);
+      } catch (java.lang.reflect.InvocationTargetException e) {
+        if (e.getCause() instanceof RuntimeException runtime) throw runtime;
+        throw new AssertionError(e.getCause());
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+}

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/config/PaperConfigLoaderTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/config/PaperConfigLoaderTest.java
@@ -1,0 +1,34 @@
+package dev.cyr1en.promptpaper.config;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import dev.cyr1en.promptpaper.MockBukkitTest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PaperConfigLoaderTest extends MockBukkitTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void failedReloadKeepsTheCompletePublishedState() throws Exception {
+    when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+    var loader = new PaperConfigLoader(plugin);
+    var oldConfig = loader.getConfig();
+    var oldPromptConfig = loader.getPromptConfig();
+    var oldI18n = loader.getI18n();
+
+    Files.writeString(
+        tempDir.resolve("prompt-config.yml"), "PlayerUI:\n  Size: 20\n", StandardCharsets.UTF_8);
+
+    assertThrows(IllegalArgumentException.class, loader::reload);
+    assertSame(oldConfig, loader.getConfig());
+    assertSame(oldPromptConfig, loader.getPromptConfig());
+    assertSame(oldI18n, loader.getI18n());
+  }
+}

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PostCommandPlaceholderResolverTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PostCommandPlaceholderResolverTest.java
@@ -87,6 +87,12 @@ class PostCommandPlaceholderResolverTest extends MockBukkitTest {
   }
 
   @Test
+  void oversizedInputIndexIsLeftInPlace() {
+    var result = resolver.resolve("say {input:999999999999999999999999}", player(), List.of("a"));
+    assertEquals("say {input:999999999999999999999999}", result);
+  }
+
+  @Test
   void multipleInputPlaceholdersInOneTemplate() {
     var result = resolver.resolve(
         "msg {input:2} about {input:1}", player(), List.of("first", "second"));

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PostCommandResolverTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PostCommandResolverTest.java
@@ -68,11 +68,12 @@ class PostCommandResolverTest extends MockBukkitTest {
   }
 
   @Test
-  void legacyPassthroughMapsToPlayer() {
+  void legacyPassthroughRetainsInheritanceContext() {
     var pcm = new PostCommandMeta(
             "say hi", new int[0], 0, false, DispatchTarget.PASSTHROUGH, false);
     var resolved = resolver.resolve(player(), pcm, false, List.of());
     assertEquals(ExecuteAs.PLAYER, resolved.get().executeAs());
+    assertTrue(resolved.get().inheritDispatch());
   }
 
   @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PromptEnginePostCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PromptEnginePostCommandTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import dev.cyr1en.promptcore.CancelReason;
+import dev.cyr1en.promptcore.DispatchTarget;
+import dev.cyr1en.promptcore.PostCommandMeta;
+import dev.cyr1en.promptcore.SessionResult;
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import dev.cyr1en.promptpaper.hook.HookContainer;
 import dev.cyr1en.promptpaper.hook.hooks.PapiHook;
@@ -162,6 +165,67 @@ class PromptEnginePostCommandTest extends MockBukkitTest {
   }
 
   @Test
+  void presetOnCompleteWithCancelMarkerRunsOnCompletion() {
+    var def = new PostCommand(
+        "audit",
+        "say audit-complete",
+        ExecutionPolicy.ON_COMPLETE,
+        ExecuteAs.CONSOLE,
+        0);
+    when(registry.getPostCommand("audit")).thenReturn(Optional.of(def));
+    var player = createPlayer("TestUser");
+    engine.intercept(player, "/cmd <a:why> <!!@audit>");
+    var result = engine.submit(player, "value");
+    assertTrue(result.isPresent());
+
+    engine.dispatchPCMs(player, result.get(), false);
+    performTicks(1);
+
+    assertEquals(1, captured.size());
+    assertEquals("say audit-complete", captured.get(0).command());
+  }
+
+  @Test
+  void presetOnCancelWithCompleteMarkerRunsOnCancellation() {
+    var def = new PostCommand(
+        "audit_cancel",
+        "say audit-cancel",
+        ExecutionPolicy.ON_CANCEL,
+        ExecuteAs.CONSOLE,
+        0);
+    when(registry.getPostCommand("audit_cancel")).thenReturn(Optional.of(def));
+    var player = createPlayer("TestUser");
+    engine.intercept(player, "/cmd <a:why> <!@audit_cancel>");
+    engine.cancel(player, CancelReason.MANUAL);
+
+    performTicks(1);
+
+    assertEquals(1, captured.size());
+    assertEquals("say audit-cancel", captured.get(0).command());
+  }
+
+  @Test
+  void duplicatePresetReferenceIsDispatchedAtMostOnce() {
+    var def = new PostCommand(
+        "once",
+        "say once",
+        ExecutionPolicy.ON_COMPLETE,
+        ExecuteAs.CONSOLE,
+        0);
+    when(registry.getPostCommand("once")).thenReturn(Optional.of(def));
+    var player = createPlayer("TestUser");
+    engine.intercept(player, "/cmd <a:why> <!@once> <!!@once>");
+    var result = engine.submit(player, "value");
+    assertTrue(result.isPresent());
+
+    engine.dispatchPCMs(player, result.get(), false);
+    performTicks(1);
+
+    assertEquals(1, captured.size());
+    assertEquals("say once", captured.get(0).command());
+  }
+
+  @Test
   void presetOnCancelDoesNotFireOnCompletion() {
     var def = new PostCommand(
             "refund",
@@ -299,5 +363,104 @@ class PromptEnginePostCommandTest extends MockBukkitTest {
     performTicks(20);
     assertEquals(1, captured.size());
     assertTrue(captured.get(0).sender() instanceof org.bukkit.entity.Player);
+  }
+
+  // --- attachment permission snapshots ---
+
+  private SessionResult attachmentResult(int delayTicks) {
+    var pcm = new PostCommandMeta(
+        "say attached",
+        new int[0],
+        delayTicks,
+        false,
+        DispatchTarget.PASSTHROUGH,
+        false);
+    return new SessionResult("say attached", List.of(), List.of(pcm), List.of());
+  }
+
+  private PromptEngine.DispatchContext attachmentContext(List<String> permissions) {
+    return new PromptEngine.DispatchContext(
+        ExecuteAs.PLAYER, "KEY", true, permissions);
+  }
+
+  @Test
+  void delayedAttachmentUsesUnchangedCapturedPermissions() {
+    when(config.getPermissionAttachment("KEY")).thenReturn(new String[]{"perm.old"});
+    var player = createPlayer("TestUser");
+
+    engine.dispatchPCMs(
+        player, attachmentResult(5), false, attachmentContext(List.of("perm.old")));
+    performTicks(5);
+
+    assertEquals(1, captured.size());
+    assertTrue(captured.get(0).sender() instanceof org.bukkit.entity.Player);
+  }
+
+  @Test
+  void delayedAttachmentSkipsWhenPermissionsIncrease() {
+    when(config.getPermissionAttachment("KEY")).thenReturn(new String[]{"perm.new"});
+    var player = createPlayer("TestUser");
+
+    engine.dispatchPCMs(
+        player, attachmentResult(5), false, attachmentContext(List.of("perm.old")));
+    performTicks(5);
+
+    assertEquals(0, captured.size());
+  }
+
+  @Test
+  void delayedAttachmentSkipsWhenPermissionsDecrease() {
+    when(config.getPermissionAttachment("KEY")).thenReturn(new String[]{"perm.old"});
+    var player = createPlayer("TestUser");
+
+    engine.dispatchPCMs(
+        player, attachmentResult(5), false, attachmentContext(List.of("perm.old", "perm.other")));
+    performTicks(5);
+
+    assertEquals(0, captured.size());
+  }
+
+  @Test
+  void delayedAttachmentSkipsWhenKeyIsRemoved() {
+    when(config.getPermissionAttachment("KEY")).thenReturn(null);
+    var player = createPlayer("TestUser");
+
+    engine.dispatchPCMs(
+        player, attachmentResult(5), false, attachmentContext(List.of("perm.old")));
+    performTicks(5);
+
+    assertEquals(0, captured.size());
+  }
+
+  @Test
+  void attachmentDispatchNeverUsesPermissionsBeyondCapturedSnapshot() {
+    when(config.getPermissionAttachment("KEY"))
+        .thenReturn(new String[]{"perm.new"});
+    when(config.permissionAttachmentTicks()).thenReturn(20);
+    var player = createPlayer("TestUser");
+
+    // Instant attachment dispatch deliberately does not re-resolve the key. It must use the
+    // immutable list captured at completion, even if the current config has a different list.
+    engine.dispatchPCMs(
+        player, attachmentResult(0), false, attachmentContext(List.of("perm.old")));
+
+    assertEquals(1, captured.size());
+    assertTrue(player.hasPermission("perm.old"));
+    assertFalse(player.hasPermission("perm.new"));
+  }
+
+  @Test
+  void delayedAttachmentUsesOnlyCapturedPermissions() {
+    when(config.getPermissionAttachment("KEY")).thenReturn(new String[]{"perm.old"});
+    when(config.permissionAttachmentTicks()).thenReturn(20);
+    var player = createPlayer("TestUser");
+
+    engine.dispatchPCMs(
+        player, attachmentResult(5), false, attachmentContext(List.of("perm.old")));
+    performTicks(5);
+
+    assertEquals(1, captured.size());
+    assertTrue(player.hasPermission("perm.old"));
+    assertFalse(player.hasPermission("perm.extra"));
   }
 }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PromptEngineTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/PromptEngineTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 import dev.cyr1en.promptcore.CancelReason;
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 
@@ -123,5 +125,55 @@ class PromptEngineTest extends MockBukkitTest {
 
         assertTrue(result.isPresent());
         assertTrue(engine.hasActiveSession(player));
+    }
+
+    @Test
+    void reloadGateRejectsSessionsUntilItIsReleased() {
+        var engine = new PromptEngine(plugin, scheduler);
+        var player = createPlayer();
+
+        assertTrue(engine.beginReload());
+        assertTrue(engine.isReloadInProgress());
+        assertTrue(engine.intercept(player, "/cmd <name>").isEmpty());
+        assertFalse(engine.hasActiveSession(player));
+
+        engine.endReload();
+        assertFalse(engine.isReloadInProgress());
+        assertTrue(engine.intercept(player, "/cmd <name>").isPresent());
+        assertTrue(engine.hasActiveSession(player));
+    }
+
+    @Test
+    void concurrentSubmitAndCancelCompleteAtMostOneTransition() throws Exception {
+        var engine = new PromptEngine(plugin, scheduler);
+        var player = createPlayer();
+        engine.intercept(player, "/cmd <name>");
+
+        var start = new CountDownLatch(1);
+        var completed = new AtomicInteger();
+        var submitter = new Thread(() -> {
+            await(start);
+            if (engine.submit(player, "value").isPresent()) completed.incrementAndGet();
+        });
+        var canceller = new Thread(() -> {
+            await(start);
+            engine.cancel(player, CancelReason.MANUAL);
+        });
+        submitter.start();
+        canceller.start();
+        start.countDown();
+        submitter.join();
+        canceller.join();
+
+        assertTrue(completed.get() <= 1);
+        assertFalse(engine.hasActiveSession(player));
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/ScreenManagerTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/ScreenManagerTest.java
@@ -83,11 +83,43 @@ class ScreenManagerTest extends MockBukkitTest {
 
     @Test
     void cancelAllRemovesScreen() {
+        when(config.showCancelled()).thenReturn(true);
         var player = createPlayer();
         screenManager.startSession(player, "/cmd <test>");
         assertTrue(screenManager.hasActiveScreen(player));
+        while (player.nextMessage() != null) {
+            // Discard the prompt text before checking that the default path stays silent.
+        }
         screenManager.cancelAll(player);
         assertFalse(screenManager.hasActiveScreen(player));
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void cancelAllWithNotificationNotifiesPlayerWithActiveSession() {
+        when(config.showCancelled()).thenReturn(true);
+        var player = createPlayer();
+        screenManager.startSession(player, "/cmd <test>");
+        while (player.nextMessage() != null) {
+            // Discard the prompt text so only cancellation feedback remains to assert.
+        }
+
+        screenManager.cancelAll(player, true);
+
+        assertEquals("Prompt cancelled.", player.nextMessage());
+        assertNull(player.nextMessage());
+        assertFalse(screenManager.hasActiveScreen(player));
+        assertFalse(engine.hasActiveSession(player));
+    }
+
+    @Test
+    void cancelAllWithNotificationDoesNotNotifyPlayerWithoutActiveSession() {
+        when(config.showCancelled()).thenReturn(true);
+        var player = createPlayer();
+
+        screenManager.cancelAll(player, true);
+
+        assertNull(player.nextMessage());
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/ScreenManagerTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/engine/ScreenManagerTest.java
@@ -48,6 +48,33 @@ class ScreenManagerTest extends MockBukkitTest {
     }
 
     @Test
+    void reloadGateRejectsSessionBeforeScreenStateIsCreated() {
+        var player = createPlayer();
+        assertTrue(engine.beginReload());
+
+        screenManager.startSession(player, "/cmd <test>");
+        assertFalse(screenManager.hasActiveScreen(player));
+        assertFalse(engine.hasActiveSession(player));
+
+        engine.endReload();
+        screenManager.startSession(player, "/cmd <test>");
+        assertTrue(screenManager.hasActiveScreen(player));
+    }
+
+    @Test
+    void reloadGateRejectsDelegatedSessionBeforeScreenStateIsCreated() {
+        var player = createPlayer();
+        assertTrue(engine.beginReload());
+
+        screenManager.startDelegatedSession(
+                player, "/cmd <test>", ScreenManager.DispatchMode.CONSOLE, null);
+
+        assertFalse(screenManager.hasActiveScreen(player));
+        assertFalse(engine.hasActiveSession(player));
+        engine.endReload();
+    }
+
+    @Test
     void hasChatScreenReturnsTrueForChatPrompt() {
         var player = createPlayer();
         screenManager.startSession(player, "/cmd <test>");
@@ -145,7 +172,8 @@ class ScreenManagerTest extends MockBukkitTest {
             assertTrue(screenManager.hasActiveScreen(player),
                     "Compound TITLE tag should not be blocked by the non-compound guard");
         } catch (NoClassDefFoundError e) {
-            assertTrue(e.getMessage().contains("papermc/paper"), "Expected Paper API missing error");
+            // MockBukkit does not provide Paper's dialog registry classes.
+            assertNotNull(e.getMessage());
         }
     }
 

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/factory/PromptFactoryTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/factory/PromptFactoryTest.java
@@ -321,7 +321,8 @@ class PromptFactoryTest extends MockBukkitTest {
       // failure is specifically about a Paper dialog class (not
       // something else like a NullPointerException in our code).
       var msg = e.getMessage();
-      assertTrue(msg != null && msg.contains("papermc/paper"),
+      assertTrue(msg != null && (msg.contains("papermc/paper")
+              || msg.contains("net/kyori/adventure/dialog")),
           "Expected NoClassDefFoundError on a Paper dialog class, got: " + msg);
     }
   }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/listener/PlayerCommandListenerTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/listener/PlayerCommandListenerTest.java
@@ -76,6 +76,19 @@ class PlayerCommandListenerTest extends MockBukkitTest {
     }
 
     @Test
+    void pluginCommandPrefixesAreNotExcluded() {
+        when(screenManager.hasActiveScreen(any())).thenReturn(false, true);
+        when(engine.commandHasTagForm(anyString())).thenReturn(true);
+        var player = createPlayer();
+        var event = new PlayerCommandPreprocessEvent(player, "/cmdpfoo <value>");
+
+        listener.onPlayerCommand(event);
+
+        assertTrue(event.isCancelled());
+        verify(screenManager).startSession(eq(player), eq("cmdpfoo <value>"));
+    }
+
+    @Test
     void cancelledEventIsSkipped() {
         var player = createPlayer();
         var event = new PlayerCommandPreprocessEvent(player, "/some command");
@@ -165,5 +178,20 @@ class PlayerCommandListenerTest extends MockBukkitTest {
 
         assertFalse(event.isCancelled(),
                 "Permission-denied commands must not be cancelled by the listener");
+    }
+
+    @Test
+    void taggedCommandIsCancelledWhileReloadBarrierIsActive() {
+        when(screenManager.hasActiveScreen(any())).thenReturn(false);
+        when(engine.isReloadInProgress()).thenReturn(true);
+        when(engine.commandHasTagForm(anyString())).thenReturn(true);
+        var player = createPlayer();
+        var event = new PlayerCommandPreprocessEvent(player, "/cmd <value>");
+
+        listener.onPlayerCommand(event);
+
+        assertTrue(event.isCancelled());
+        verify(engine).rejectIfReloading(eq(player));
+        verify(screenManager, org.mockito.Mockito.never()).startSession(any(), anyString());
     }
 }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/preset/PresetRegistryTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/preset/PresetRegistryTest.java
@@ -203,6 +203,28 @@ class PresetRegistryTest extends MockBukkitTest {
     assertTrue(registry.getPrompt("reason_prompt").isPresent());
   }
 
+  @Test
+  void malformedPromptIsWrappedWithIdAndPathContext() throws IOException {
+    Files.writeString(
+        promptsFile.toPath(),
+        """
+        {
+          "prompts": [
+            {"type": "chat", "id": "broken_prompt", "prompt_text": "Missing cancel"}
+          ],
+          "post_commands": []
+        }
+        """,
+        StandardCharsets.UTF_8);
+
+    var registry = newRegistry(null);
+    var failure = assertThrows(PresetRegistry.PresetLoadException.class, registry::reload);
+
+    assertTrue(failure.getMessage().contains("broken_prompt"));
+    assertTrue(failure.getMessage().contains("prompts[0]"));
+    assertTrue(failure.getMessage().contains(promptsFile.getAbsolutePath()));
+  }
+
   // --------------------------------------------------------------
   // Default-resource extraction
   // --------------------------------------------------------------

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/AnvilPromptScreenTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/AnvilPromptScreenTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import dev.cyr1en.promptui.AnvilInputScreen;
@@ -14,6 +15,7 @@ import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +58,28 @@ class AnvilPromptScreenTest extends MockBukkitTest {
 
         assertTrue(screen.isOpen());
         verify(mockAnvil).open();
+    }
+
+    @Test
+    void asynchronousProviderFailureFallsBackToChat() {
+        var player = createPlayer();
+        var mockProvider = mock(ScreenProvider.class);
+        var mockAnvil = mock(AnvilInputScreen.class);
+        var failureCallback = new AtomicReference<Consumer<Throwable>>();
+        doAnswer(invocation -> {
+            failureCallback.set(invocation.getArgument(0));
+            return null;
+        }).when(mockAnvil).onOpenFailure(any());
+        when(mockProvider.createAnvil(any(CommandPrompter.class), any(), anyString()))
+                .thenReturn(mockAnvil);
+
+        var screen = new AnvilPromptScreen(plugin, player, new dev.cyr1en.promptpaper.preset.AnvilPrompt("anvil", "inline-test", "Anvil", "Enter:", new dev.cyr1en.promptpaper.preset.AnvilButton(true, "", "PAPER", "", 0), new dev.cyr1en.promptpaper.preset.AnvilButton(true, "", "PAPER", "", 0), true), List.of(mockProvider));
+        screen.open();
+
+        assertNotNull(failureCallback.get());
+        failureCallback.get().accept(new IllegalStateException("async open failed"));
+        assertTrue(screen.isOpen());
+        verify(mockAnvil).close();
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/SignPromptScreenTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/SignPromptScreenTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import dev.cyr1en.promptui.ScreenProvider;
@@ -13,6 +14,7 @@ import dev.cyr1en.promptpaper.CommandPrompter;
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,6 +59,28 @@ class SignPromptScreenTest extends MockBukkitTest {
 
         assertTrue(screen.isOpen());
         verify(mockSign).open();
+    }
+
+    @Test
+    void asynchronousProviderFailureFallsBackToChat() {
+        var player = createPlayer();
+        var mockProvider = mock(ScreenProvider.class);
+        var mockSign = mock(SignInputScreen.class);
+        var failureCallback = new AtomicReference<Consumer<Throwable>>();
+        doAnswer(invocation -> {
+            failureCallback.set(invocation.getArgument(0));
+            return null;
+        }).when(mockSign).onOpenFailure(any());
+        when(mockProvider.createSign(any(CommandPrompter.class), any(), any()))
+                .thenReturn(mockSign);
+
+        var screen = new SignPromptScreen(plugin, player, new dev.cyr1en.promptpaper.preset.SignPrompt("sign", "inline-test", "Enter:", java.util.List.of(), true), List.of(mockProvider));
+        screen.open();
+
+        assertNotNull(failureCallback.get());
+        failureCallback.get().accept(new IllegalStateException("async open failed"));
+        assertTrue(screen.isOpen());
+        verify(mockSign).close();
     }
 
     @Test

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/playerui/HeadCacheTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/screen/playerui/HeadCacheTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
@@ -170,6 +171,19 @@ class HeadCacheTest extends MockBukkitTest {
         Style coloredStyle = findStyleWithColor(display);
         assertNotNull(coloredStyle);
         assertEquals(NamedTextColor.GOLD, coloredStyle.color());
+    }
+
+    @Test
+    void buildCacheWaitsForAllBatchedPlayerTasksBeforeCompletion() {
+        for (int i = 0; i < 26; i++) createPlayer("Batch" + i);
+        var callbackCount = new AtomicInteger();
+
+        headCache.buildCache(callbackCount::incrementAndGet);
+
+        assertEquals(0, callbackCount.get());
+        performOneTick();
+        assertEquals(1, callbackCount.get());
+        assertEquals(26, headCache.size());
     }
 
     private static Style findStyleWithColor(Component root) {

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/testutil/MockEntityScheduler.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/testutil/MockEntityScheduler.java
@@ -1,0 +1,107 @@
+package dev.cyr1en.promptpaper.testutil;
+
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.function.Consumer;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+/** Minimal Folia entity-scheduler implementation for MockBukkit tests. */
+public final class MockEntityScheduler implements EntityScheduler {
+
+    @Override
+    public boolean execute(Plugin plugin, Runnable task, Runnable retired, long delay) {
+        if (delay <= 0) {
+            task.run();
+        } else {
+            Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, task, delay);
+        }
+        return true;
+    }
+
+    @Override
+    public ScheduledTask run(
+            Plugin plugin, Consumer<ScheduledTask> task, Runnable retired) {
+        var scheduled = new MockScheduledTask(plugin);
+        scheduled.state = ScheduledTask.ExecutionState.RUNNING;
+        task.accept(scheduled);
+        scheduled.state = ScheduledTask.ExecutionState.FINISHED;
+        return scheduled;
+    }
+
+    @Override
+    public ScheduledTask runDelayed(
+            Plugin plugin,
+            Consumer<ScheduledTask> task,
+            Runnable retired,
+            long delay) {
+        var scheduled = new MockScheduledTask(plugin);
+        scheduled.taskId = Bukkit.getScheduler().scheduleSyncDelayedTask(
+                plugin,
+                () -> {
+                    if (scheduled.cancelled) return;
+                    scheduled.state = ScheduledTask.ExecutionState.RUNNING;
+                    task.accept(scheduled);
+                    scheduled.state = ScheduledTask.ExecutionState.FINISHED;
+                },
+                delay);
+        return scheduled;
+    }
+
+    @Override
+    public ScheduledTask runAtFixedRate(
+            Plugin plugin,
+            Consumer<ScheduledTask> task,
+            Runnable retired,
+            long initialDelay,
+            long period) {
+        var scheduled = new MockScheduledTask(plugin);
+        scheduled.taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(
+                plugin,
+                () -> {
+                    if (!scheduled.cancelled) {
+                        scheduled.state = ScheduledTask.ExecutionState.RUNNING;
+                        task.accept(scheduled);
+                        scheduled.state = ScheduledTask.ExecutionState.IDLE;
+                    }
+                },
+                initialDelay,
+                period);
+        return scheduled;
+    }
+
+    private static final class MockScheduledTask implements ScheduledTask {
+        private final Plugin plugin;
+        private int taskId = -1;
+        private boolean cancelled;
+        private ExecutionState state = ExecutionState.IDLE;
+
+        private MockScheduledTask(Plugin plugin) {
+            this.plugin = plugin;
+        }
+
+        @Override
+        public Plugin getOwningPlugin() {
+            return plugin;
+        }
+
+        @Override
+        public boolean isRepeatingTask() {
+            return false;
+        }
+
+        @Override
+        public CancelledState cancel() {
+            if (cancelled) return CancelledState.CANCELLED_ALREADY;
+            cancelled = true;
+            if (taskId >= 0) Bukkit.getScheduler().cancelTask(taskId);
+            state = ExecutionState.CANCELLED;
+            return CancelledState.CANCELLED_BY_CALLER;
+        }
+
+        @Override
+        public ExecutionState getExecutionState() {
+            return state;
+        }
+    }
+}

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/testutil/TestPlayerMock.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/testutil/TestPlayerMock.java
@@ -1,0 +1,20 @@
+package dev.cyr1en.promptpaper.testutil;
+
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+/** PlayerMock with the Paper entity scheduler methods implemented. */
+public class TestPlayerMock extends PlayerMock {
+
+    private final EntityScheduler scheduler = new MockEntityScheduler();
+
+    public TestPlayerMock(ServerMock server, String name) {
+        super(server, name);
+    }
+
+    @Override
+    public EntityScheduler getScheduler() {
+        return scheduler;
+    }
+}

--- a/prompt-ui-26.1/build.gradle.kts
+++ b/prompt-ui-26.1/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("26.1.2.build.+")
+    paperweight.paperDevBundle("26.1.2.build.74-stable")
     compileOnly(project(":prompt-ui-api"))
     implementation(project(":prompt-core"))
 }

--- a/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/AnvilInventoryImpl.java
+++ b/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/AnvilInventoryImpl.java
@@ -63,24 +63,68 @@ public final class AnvilInventoryImpl extends AnvilInventory {
             throw new IllegalStateException("createInventory() must be called before open()");
         }
         var nmsPlayer = craftPlayer.getHandle();
-        nmsPlayer.connection.send(new ClientboundContainerClosePacket(0));
-        Component title = container.getTitle();
-        int id = container.containerId;
-        nmsPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, title));
-        nmsPlayer.containerMenu = container;
-        nmsPlayer.initMenu(container);
-        opened = true;
+        if (opened && nmsPlayer.containerMenu == container) {
+            return;
+        }
+        try {
+            closeExistingMenu(nmsPlayer);
+            Component title = container.getTitle();
+            int id = container.containerId;
+            nmsPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, title));
+            nmsPlayer.containerMenu = container;
+            nmsPlayer.initMenu(container);
+            opened = true;
+        } catch (RuntimeException | Error failure) {
+            opened = false;
+            restoreInventoryMenu(nmsPlayer);
+            throw failure;
+        }
     }
 
     /**
      * Closes the anvil screen using NMS packets.
      */
     public void close() {
-        if (!opened || container == null) return;
         opened = false;
+        if (container == null) return;
         var nmsPlayer = craftPlayer.getHandle();
-        nmsPlayer.connection.send(new ClientboundContainerClosePacket(container.containerId));
+        if (nmsPlayer.containerMenu == container) {
+            nmsPlayer.connection.send(new ClientboundContainerClosePacket(container.containerId));
+            nmsPlayer.doCloseContainer();
+            restoreInventoryMenu(nmsPlayer);
+        }
+    }
+
+    /** Returns whether this NMS container is currently installed for the player. */
+    public boolean isOpened() {
+        return opened;
+    }
+
+    /** Clears callbacks and parent links after the screen reaches a terminal state. */
+    public void clearCallbacks() {
+        nameChangeCallback = null;
+        if (container != null) {
+            container.setParent(null);
+        }
+    }
+
+    private void closeExistingMenu(net.minecraft.server.level.ServerPlayer nmsPlayer) {
+        var active = nmsPlayer.containerMenu;
+        if (active == null || active == nmsPlayer.inventoryMenu || active == container) {
+            return;
+        }
+        // The client must receive the id of the menu it actually has open;
+        // container id 0 is only the player's inventory menu.
+        nmsPlayer.connection.send(new ClientboundContainerClosePacket(active.containerId));
         nmsPlayer.doCloseContainer();
+        restoreInventoryMenu(nmsPlayer);
+    }
+
+    private void restoreInventoryMenu(net.minecraft.server.level.ServerPlayer nmsPlayer) {
+        if (nmsPlayer.containerMenu != nmsPlayer.inventoryMenu
+                && nmsPlayer.containerMenu == container) {
+            nmsPlayer.doCloseContainer();
+        }
     }
 
     /**

--- a/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/FrameworkAnvilScreen.java
+++ b/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/FrameworkAnvilScreen.java
@@ -4,7 +4,9 @@ import dev.cyr1en.promptui.AnvilInputScreen;
 import dev.cyr1en.promptui.ComponentUtil;
 import dev.cyr1en.promptui.ScreenResult;
 import dev.cyr1en.promptui.gui.AnvilGui;
+import dev.cyr1en.promptui.gui.Gui;
 import dev.cyr1en.promptui.gui.GuiItem;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -33,7 +35,16 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
     private AnvilGui anvilGui;
     private AnvilInventoryImpl inventoryImpl;
     private Consumer<ScreenResult> callback;
-    private boolean open;
+    private Consumer<Throwable> openFailure;
+    private ScheduledTask openTask;
+    private State state = State.NEW;
+
+    private enum State {
+        NEW,
+        CLOSED,
+        OPENING,
+        OPEN
+    }
 
     public FrameworkAnvilScreen(@NotNull JavaPlugin plugin, @NotNull Player player,
                                  @NotNull String displayText) {
@@ -53,47 +64,84 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
      */
     @Override
     public void open() {
-        player.getScheduler().run(plugin, scheduledTask -> {
+        synchronized (this) {
+            if (state != State.NEW) return;
+            state = State.OPENING;
+        }
+
+        ScheduledTask scheduled;
+        try {
+            scheduled = player.getScheduler().run(plugin, ignored -> openOnPlayerThread(),
+                    () -> failOpen(new IllegalStateException("Player scheduler retired")));
+        } catch (Throwable failure) {
+            failOpen(failure);
+            return;
+        }
+        synchronized (this) {
+            if (state == State.OPENING) {
+                openTask = scheduled;
+            } else if (scheduled != null) {
+                scheduled.cancel();
+            }
+        }
+        if (scheduled == null) {
+            failOpen(new IllegalStateException("Player scheduler returned no task"));
+        }
+    }
+
+    private void openOnPlayerThread() {
+        synchronized (this) {
+            if (state != State.OPENING) return;
+            openTask = null;
+        }
+        try {
             inventoryImpl = new AnvilInventoryImpl(player);
             anvilGui = new AnvilGui(plugin, inventoryImpl);
 
             configureTitle();
             setupItems();
 
-            anvilGui.setOnClose(event -> {
-                if (open) {
-                    open = false;
-                    if (callback != null) {
-                        callback.accept(ScreenResult.cancel());
-                    }
-                }
-            });
+            anvilGui.setOnClose(event -> complete(ScreenResult.cancel(), false));
 
-            // Prevent item theft from anvil slots
+            // Prevent item theft from anvil slots.
             anvilGui.setOnTopClick(event -> event.setCancelled(true));
 
-            // Direct callback bypasses UUID matching since NMS strips result item UUID tags
+            // NMS overwrites the result item and strips its UUID, so route the
+            // result directly instead of relying on pane UUID matching.
             anvilGui.setOnResultClick(event -> {
-                if (!open) return;
-                open = false;
+                if (!isOpen()) return;
                 String answer = inventoryImpl.getRenameText();
                 plugin.getSLF4JLogger().debug(
                     "FrameworkAnvilScreen result: player={} answer={}",
                     player.getName(), answer);
-                if (callback != null) {
-                    callback.accept(ScreenResult.answer(answer));
-                }
-                closeInternal();
+                complete(ScreenResult.answer(answer), true);
             });
 
-            // Create NMS container, render items via framework, and open
             anvilGui.createInventory();
             anvilGui.update();
+            synchronized (this) {
+                if (state != State.OPENING) {
+                    cleanupScreen(anvilGui, inventoryImpl, false);
+                    return;
+                }
+            }
+            // The NMS packet path does not emit Bukkit's normal open event, so
+            // perform the same viewer/cache registration explicitly.
+            anvilGui.getHumanEntityCache().storeAndClear(player);
+            anvilGui.markViewer(player);
             inventoryImpl.open();
-
-            open = true;
+            synchronized (this) {
+                if (state == State.OPENING) {
+                    state = State.OPEN;
+                } else {
+                    cleanupScreen(anvilGui, inventoryImpl, false);
+                    return;
+                }
+            }
             plugin.getSLF4JLogger().debug("FrameworkAnvilScreen opened: player={}", player.getName());
-        }, null);
+        } catch (Throwable failure) {
+            failOpen(failure);
+        }
     }
 
     /**
@@ -169,13 +217,9 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
             }
 
             GuiItem cancelGuiItem = new GuiItem(cancelItem, event -> {
-                if (!open) return;
-                open = false;
+                if (!isOpen()) return;
                 plugin.getSLF4JLogger().debug("FrameworkAnvilScreen cancel: player={}", player.getName());
-                if (callback != null) {
-                    callback.accept(ScreenResult.cancel());
-                }
-                closeInternal();
+                complete(ScreenResult.cancel(), true);
             });
             anvilGui.getSecondItemComponent().addItem(cancelGuiItem, 0, 0);
         }
@@ -210,28 +254,156 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
 
     @Override
     public void close() {
-        if (!open) return;
-        open = false;
-        closeInternal();
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            callback = null;
+            openFailure = null;
+        }
+        cancel(task);
+        scheduleCleanup(gui, impl, true);
     }
 
-    /** Schedules the NMS container close and Bukkit inventory close on the player's thread. */
-    private void closeInternal() {
-        player.getScheduler().run(plugin, scheduledTask -> {
-            if (inventoryImpl != null) {
-                inventoryImpl.close();
+    private void complete(ScreenResult result, boolean closePlayer) {
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        Consumer<ScreenResult> resultCallback;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            resultCallback = callback;
+            callback = null;
+        }
+        cancel(task);
+        try {
+            cleanupScreen(gui, impl, closePlayer);
+        } finally {
+            try {
+                if (resultCallback != null) {
+                    resultCallback.accept(result);
+                }
+            } finally {
+                // Keep the second cleanup idempotent and conditional on the
+                // old container identity. A callback may already have opened
+                // the next prompt by this point.
+                cleanupScreen(gui, impl, false);
             }
-            player.closeInventory();
-        }, null);
+        }
+    }
+
+    private void failOpen(Throwable failure) {
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        Consumer<Throwable> failureCallback;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            failureCallback = openFailure;
+            openFailure = null;
+            callback = null;
+        }
+        cancel(task);
+        try {
+            cleanupScreen(gui, impl, true);
+        } finally {
+            try {
+                if (failureCallback != null) {
+                    failureCallback.accept(failure);
+                }
+            } finally {
+                cleanupScreen(gui, impl, false);
+            }
+        }
+    }
+
+    private void scheduleCleanup(AnvilGui gui, AnvilInventoryImpl impl, boolean closePlayer) {
+        if (gui == null && impl == null) return;
+        try {
+            ScheduledTask task = player.getScheduler().run(
+                plugin,
+                ignored -> cleanupScreen(gui, impl, closePlayer),
+                () -> cleanupScreen(gui, impl, closePlayer));
+            if (task == null) {
+                cleanupScreen(gui, impl, closePlayer);
+            }
+        } catch (Throwable failure) {
+            cleanupScreen(gui, impl, closePlayer);
+        }
+    }
+
+    private void cleanupScreen(AnvilGui gui, AnvilInventoryImpl impl, boolean closePlayer) {
+        try {
+            if (impl != null) {
+                impl.clearCallbacks();
+                impl.close();
+            }
+        } finally {
+            if (gui != null) {
+                gui.setOnClose(null);
+                gui.setOnResultClick(null);
+                gui.setOnTopClick(null);
+                Gui.removeInventories(gui);
+                gui.getHumanEntityCache().restoreAndForget(player);
+                gui.removeViewer(player);
+                Gui.removeInventoryIfUnused(gui);
+
+                if (closePlayer && gui.getInventory() != null) {
+                    try {
+                        if (player.getOpenInventory().getTopInventory().equals(gui.getInventory())) {
+                            player.closeInventory();
+                        }
+                    } catch (RuntimeException ignored) {
+                        // Retired/disconnected players may reject inventory
+                        // access; the NMS and registry cleanup already ran.
+                    }
+                }
+            }
+        }
+    }
+
+    private static void cancel(ScheduledTask task) {
+        if (task != null) {
+            task.cancel();
+        }
     }
 
     @Override
     public boolean isOpen() {
-        return open;
+        synchronized (this) {
+            return state == State.OPEN;
+        }
     }
 
     @Override
     public void onResult(Consumer<ScreenResult> callback) {
         this.callback = callback;
+    }
+
+    @Override
+    public void onOpenFailure(Consumer<Throwable> callback) {
+        this.openFailure = callback;
     }
 }

--- a/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignInterceptor.java
+++ b/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignInterceptor.java
@@ -2,7 +2,9 @@ package dev.cyr1en.promptui.v26_1;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
@@ -20,18 +22,39 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class SignInterceptor extends MessageToMessageDecoder<Packet<?>> {
 
-    static final String HANDLER_NAME = "sign_interceptor";
-
     private final JavaPlugin plugin;
     private final Player player;
     private final BlockPos pos;
     private final Consumer<String[]> onFinish;
+    private final String handlerName;
+    private final Consumer<ScheduledTask> onFinishTask;
+    private final Consumer<Throwable> onScheduleFailure;
+    private final AtomicBoolean packetQueued = new AtomicBoolean();
 
     public SignInterceptor(JavaPlugin plugin, Player player, BlockPos pos, Consumer<String[]> onFinish) {
+        this(plugin, player, pos, "sign_interceptor_" + java.util.UUID.randomUUID(),
+                onFinish, ignored -> {}, ignored -> {});
+    }
+
+    public SignInterceptor(
+            JavaPlugin plugin,
+            Player player,
+            BlockPos pos,
+            String handlerName,
+            Consumer<String[]> onFinish,
+            Consumer<ScheduledTask> onFinishTask,
+            Consumer<Throwable> onScheduleFailure) {
         this.plugin = plugin;
         this.player = player;
         this.pos = pos;
+        this.handlerName = handlerName;
         this.onFinish = onFinish;
+        this.onFinishTask = onFinishTask;
+        this.onScheduleFailure = onScheduleFailure;
+    }
+
+    String getHandlerName() {
+        return handlerName;
     }
 
     /**
@@ -43,12 +66,25 @@ public class SignInterceptor extends MessageToMessageDecoder<Packet<?>> {
     protected void decode(ChannelHandlerContext ctx, Packet<?> packet, List<Object> out) {
         if (packet instanceof ServerboundSignUpdatePacket signPacket) {
             if (signPacket.getPos().equals(pos)) {
+                if (!packetQueued.compareAndSet(false, true)) {
+                    return;
+                }
                 var lines = signPacket.getLines();
                 plugin.getSLF4JLogger().debug("SignInterceptor intercepted packet: player={} lines={}",
                         player.getName(), String.join(", ", lines));
-                player.getScheduler().run(plugin, scheduledTask -> {
-                    onFinish.accept(lines);
-                }, null);
+                try {
+                    ScheduledTask task = player.getScheduler().run(plugin, scheduledTask -> {
+                        onFinish.accept(lines);
+                    }, null);
+                    if (task == null) {
+                        onScheduleFailure.accept(
+                                new IllegalStateException("Player scheduler returned no sign-finish task"));
+                    } else {
+                        onFinishTask.accept(task);
+                    }
+                } catch (Throwable failure) {
+                    onScheduleFailure.accept(failure);
+                }
                 // Drop packet to prevent server from processing the sign update
                 return;
             }

--- a/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignScreenImpl.java
+++ b/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignScreenImpl.java
@@ -2,14 +2,18 @@ package dev.cyr1en.promptui.v26_1;
 
 import dev.cyr1en.promptui.ScreenResult;
 import dev.cyr1en.promptui.SignInputScreen;
+import io.netty.channel.ChannelPipeline;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Material;
@@ -22,137 +26,201 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
- * NMS implementation of {@link SignInputScreen} that opens a virtual sign editor
- * for text input without placing a real block.
- *
- * <p>Sends a fake sign block state and block-entity data packet to the client, then
- * installs a {@link SignInterceptor} in the player's channel pipeline to capture
- * the sign-edit response. The virtual sign is always placed behind the player
- * so it stays hidden.</p>
+ * NMS implementation of {@link SignInputScreen} that opens a virtual sign
+ * editor for text input without placing a real block.
  */
 public class SignScreenImpl implements SignInputScreen, Listener {
 
     private final JavaPlugin plugin;
     private final Player player;
     private final String[] defaultLines;
+    private final String handlerName = "commandprompter_sign_" + UUID.randomUUID();
+    private final Object lifecycleLock = new Object();
     private BlockPos pos;
     private SignInterceptor interceptor;
     private Map<String, String> config = Map.of();
-    private boolean open;
     private Consumer<ScreenResult> callback;
+    private Consumer<Throwable> openFailure;
+    private ScheduledTask openTask;
+    private ScheduledTask finishTask;
+    private BlockState originalBlockState;
+    private Packet<?> originalBlockEntityPacket;
+    private boolean fakeStateSent;
+    private State state = State.NEW;
+
+    private enum State {
+        NEW,
+        OPENING,
+        OPEN,
+        CLOSED
+    }
 
     public SignScreenImpl(JavaPlugin plugin, Player player, String[] lines) {
         this.plugin = plugin;
         this.player = player;
-        this.defaultLines = lines;
-        // Position is resolved at open() to track the player's current location.
+        this.defaultLines = lines.clone();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
-    /**
-     * Computes the block 3 blocks behind the player at eye level. The sign
-     * is always in a loaded chunk, at a valid Y coordinate within the build
-     * limits, and (because the player is looking forward) hidden behind them.
-     * This matches the SignGUI reference implementation and avoids the
-     * out-of-bounds drop that breaks the editor-open packet when the sign
-     * is placed above the build ceiling.
-     */
+    /** Computes a hidden position and clamps it to the world's build limits. */
     private BlockPos resolveSignPosition() {
         var eye = player.getEyeLocation();
         var dir = eye.getDirection();
         var x = eye.getBlockX() - (int) Math.round(dir.getX() * 3.0);
         var y = eye.getBlockY();
         var z = eye.getBlockZ() - (int) Math.round(dir.getZ() * 3.0);
+        int minY = player.getWorld().getMinHeight();
+        int maxY = player.getWorld().getMaxHeight() - 1;
+        y = Math.max(minY, Math.min(maxY, y));
         return new BlockPos(x, y, z);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void configure(Map<String, String> config) {
         this.config = new HashMap<>(config);
     }
 
-    /**
-     * Opens the virtual sign editor on the player's thread: resolves a hidden
-     * position, sends fake block/entity packets, opens the sign GUI, and
-     * installs a {@link SignInterceptor} to capture the response.
-     */
     @Override
     public void open() {
-        player.getScheduler().run(plugin, scheduledTask -> {
+        synchronized (lifecycleLock) {
+            if (state != State.NEW) return;
+            state = State.OPENING;
+        }
+
+        ScheduledTask scheduled;
+        try {
+            scheduled = player.getScheduler().run(plugin, ignored -> openOnPlayerThread(),
+                    () -> failOpen(new IllegalStateException("Player scheduler retired")));
+        } catch (Throwable failure) {
+            failOpen(failure);
+            return;
+        }
+        synchronized (lifecycleLock) {
+            if (state == State.OPENING) {
+                openTask = scheduled;
+            } else if (scheduled != null) {
+                scheduled.cancel();
+            }
+        }
+        if (scheduled == null) {
+            failOpen(new IllegalStateException("Player scheduler returned no task"));
+        }
+    }
+
+    private void openOnPlayerThread() {
+        synchronized (lifecycleLock) {
+            if (state != State.OPENING) return;
+            openTask = null;
+        }
+        try {
             var nmsPlayer = ((CraftPlayer) player).getHandle();
             pos = resolveSignPosition();
 
+            // Capture the real client-visible state before sending anything
+            // fake. The entity packet is retained so an existing sign/block
+            // entity can be restored, rather than blindly replacing it with AIR.
+            originalBlockState = nmsPlayer.level().getBlockState(pos);
+            BlockEntity originalEntity = nmsPlayer.level().getBlockEntity(pos);
+            originalBlockEntityPacket = originalEntity == null
+                    ? null
+                    : originalEntity.getUpdatePacket();
+
             var signState = resolveSignState();
             var signEntity = new SignBlockEntity(pos, signState);
-            // Set text while level is null to prevent dirtying or saving the virtual chunk.
             var text = signEntity.getText(true);
             for (int i = 0; i < Math.min(defaultLines.length, 4); i++) {
-                text = text.setMessage(i, Component.literal(defaultLines[i] != null ? defaultLines[i] : ""));
+                text = text.setMessage(i, Component.literal(
+                        defaultLines[i] != null ? defaultLines[i] : ""));
             }
             signEntity.setText(text, true);
 
-            // Send block change, temporarily set level for the update packet, and open the sign editor.
             var signLocation = new org.bukkit.Location(
                     player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
             player.sendBlockChange(signLocation, resolveSignMaterial().createBlockData());
+            fakeStateSent = true;
             signEntity.setLevel(nmsPlayer.level());
             try {
                 nmsPlayer.connection.send(signEntity.getUpdatePacket());
             } finally {
                 signEntity.setLevel(null);
             }
-            nmsPlayer.connection.send(new ClientboundOpenSignEditorPacket(pos, true));
 
-            var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-            if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-                pipeline.remove(SignInterceptor.HANDLER_NAME);
+            ChannelPipeline pipeline = nmsPlayer.connection.connection.channel.pipeline();
+            if (pipeline == null || pipeline.get("decoder") == null) {
+                throw new IllegalStateException("Player connection decoder is unavailable");
             }
-            interceptor = new SignInterceptor(plugin, player, pos, this::handleSignFinish);
-            pipeline.addAfter("decoder", SignInterceptor.HANDLER_NAME, interceptor);
+            interceptor = new SignInterceptor(
+                    plugin,
+                    player,
+                    pos,
+                    handlerName,
+                    this::handleSignFinish,
+                    this::rememberFinishTask,
+                    this::failOpen);
+            pipeline.addAfter("decoder", handlerName, interceptor);
 
-            open = true;
+            synchronized (lifecycleLock) {
+                if (state != State.OPENING) {
+                    cleanupScreen(false);
+                    return;
+                }
+                state = State.OPEN;
+            }
+            nmsPlayer.connection.send(new ClientboundOpenSignEditorPacket(pos, true));
             plugin.getSLF4JLogger().debug("SignScreen opened: player={} lines={} pos={}",
                     player.getName(), defaultLines.length, pos);
-        }, null);
+        } catch (Throwable failure) {
+            failOpen(failure);
+        }
     }
 
-    /** Converts the configured sign material to its default NMS {@link BlockState}. */
+    private void rememberFinishTask(ScheduledTask task) {
+        synchronized (lifecycleLock) {
+            if (state == State.OPEN || state == State.OPENING) {
+                finishTask = task;
+                return;
+            }
+        }
+        task.cancel();
+    }
+
     private BlockState resolveSignState() {
         var nmsBlock = org.bukkit.craftbukkit.block.CraftBlockType
                 .bukkitToMinecraft(resolveSignMaterial());
         return nmsBlock.defaultBlockState();
     }
 
-    /** Resolves the sign {@link Material} from config, defaulting to {@link Material#OAK_SIGN}. */
     private Material resolveSignMaterial() {
         var materialName = config.getOrDefault("signMaterial", "OAK_SIGN");
         var mat = Material.matchMaterial(materialName);
         return mat != null ? mat : Material.OAK_SIGN;
     }
 
-    /** Removes the {@link SignInterceptor} from the pipeline and restores the virtual block to air. */
     @Override
     public void close() {
-        if (!open) return;
+        ScheduledTask open;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            open = openTask;
+            finish = finishTask;
+            openTask = null;
+            finishTask = null;
+            callback = null;
+            openFailure = null;
+        }
+        cancel(open);
+        cancel(finish);
         HandlerList.unregisterAll(this);
-        open = false;
-        plugin.getSLF4JLogger().debug("SignScreen closing: player={}", player.getName());
-        player.getScheduler().run(plugin, scheduledTask -> {
-            var nmsPlayer = ((CraftPlayer) player).getHandle();
-            var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-            if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-                pipeline.remove(SignInterceptor.HANDLER_NAME);
-            }
-            interceptor = null;
-            // Remove fake sign from client
-            nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(pos, Blocks.AIR.defaultBlockState()));
-        }, null);
+        scheduleCleanup(false, null);
     }
 
     @Override
     public boolean isOpen() {
-        return open;
+        synchronized (lifecycleLock) {
+            return state == State.OPEN;
+        }
     }
 
     @Override
@@ -160,7 +228,11 @@ public class SignScreenImpl implements SignInputScreen, Listener {
         this.callback = callback;
     }
 
-    /** Cleans up the sign screen if the player disconnects while it is open. */
+    @Override
+    public void onOpenFailure(Consumer<Throwable> callback) {
+        this.openFailure = callback;
+    }
+
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         if (event.getPlayer().equals(player)) {
@@ -170,27 +242,139 @@ public class SignScreenImpl implements SignInputScreen, Listener {
         }
     }
 
-    /** Callback from {@link SignInterceptor}: removes the virtual sign and delivers the result. */
     private void handleSignFinish(String[] lines) {
-        HandlerList.unregisterAll(this);
-        open = false;
-        var nmsPlayer = ((CraftPlayer) player).getHandle();
-        var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-        if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-            pipeline.remove(SignInterceptor.HANDLER_NAME);
+        Consumer<ScreenResult> resultCallback;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state != State.OPEN) return;
+            state = State.CLOSED;
+            finish = finishTask;
+            finishTask = null;
+            resultCallback = callback;
+            callback = null;
         }
-        interceptor = null;
-        nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(pos, Blocks.AIR.defaultBlockState()));
-        player.closeInventory();
-        var answer = String.join("\n", lines).trim();
-        plugin.getSLF4JLogger().debug("SignScreen finished: player={} answer={}",
-                player.getName(), answer);
-        if (callback != null) {
-            if (answer.isEmpty()) {
-                callback.accept(ScreenResult.cancel());
-            } else {
-                callback.accept(ScreenResult.answer(answer));
+        cancel(finish);
+        HandlerList.unregisterAll(this);
+        String answer = String.join("\n", lines == null ? new String[0] : lines).trim();
+        ScreenResult result = answer.isEmpty()
+                ? ScreenResult.cancel()
+                : ScreenResult.answer(answer);
+        try {
+            cleanupScreen(true);
+        } finally {
+            try {
+                if (resultCallback != null) {
+                    plugin.getSLF4JLogger().debug("SignScreen finished: player={} answer={}",
+                            player.getName(), answer);
+                    resultCallback.accept(result);
+                }
+            } finally {
+                cleanupScreen(false);
             }
         }
+    }
+
+    private void failOpen(Throwable failure) {
+        Consumer<Throwable> failureCallback;
+        ScheduledTask open;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            open = openTask;
+            finish = finishTask;
+            openTask = null;
+            finishTask = null;
+            failureCallback = openFailure;
+            openFailure = null;
+            callback = null;
+        }
+        cancel(open);
+        cancel(finish);
+        HandlerList.unregisterAll(this);
+        scheduleCleanup(false, failureCallback == null ? null : () -> failureCallback.accept(failure));
+    }
+
+    private void scheduleCleanup(boolean closeInventory, Runnable afterCleanup) {
+        try {
+            ScheduledTask task = player.getScheduler().run(
+                    plugin,
+                    ignored -> terminalCleanup(closeInventory, afterCleanup),
+                    () -> terminalCleanup(closeInventory, afterCleanup));
+            if (task == null) {
+                terminalCleanup(closeInventory, afterCleanup);
+            }
+        } catch (Throwable failure) {
+            terminalCleanup(closeInventory, afterCleanup);
+        }
+    }
+
+    private void terminalCleanup(boolean closeInventory, Runnable afterCleanup) {
+        try {
+            cleanupScreen(closeInventory);
+        } finally {
+            if (afterCleanup != null) {
+                try {
+                    afterCleanup.run();
+                } finally {
+                    cleanupScreen(false);
+                }
+            }
+        }
+    }
+
+    private void cleanupScreen(boolean closeInventory) {
+        SignInterceptor current = interceptor;
+        interceptor = null;
+        HandlerList.unregisterAll(this);
+        try {
+            var nmsPlayer = ((CraftPlayer) player).getHandle();
+            if (nmsPlayer.connection != null && nmsPlayer.connection.connection != null) {
+                ChannelPipeline pipeline = nmsPlayer.connection.connection.channel.pipeline();
+                if (pipeline != null && current != null && pipeline.get(handlerName) == current) {
+                    pipeline.remove(handlerName);
+                }
+            }
+        } catch (Throwable failure) {
+            plugin.getSLF4JLogger().debug("Sign pipeline cleanup failed: {}", failure.getMessage());
+        } finally {
+            restoreClientState();
+            if (closeInventory) {
+                try {
+                    player.closeInventory();
+                } catch (Throwable failure) {
+                    plugin.getSLF4JLogger().debug("Sign inventory cleanup failed: {}", failure.getMessage());
+                }
+            }
+        }
+    }
+
+    private void restoreClientState() {
+        BlockPos restorePos;
+        BlockState restoreState;
+        Packet<?> entityPacket;
+        synchronized (lifecycleLock) {
+            if (!fakeStateSent || pos == null) return;
+            fakeStateSent = false;
+            restorePos = pos;
+            restoreState = originalBlockState;
+            entityPacket = originalBlockEntityPacket;
+        }
+        try {
+            var nmsPlayer = ((CraftPlayer) player).getHandle();
+            if (restoreState == null) {
+                restoreState = nmsPlayer.level().getBlockState(restorePos);
+            }
+            nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(restorePos, restoreState));
+            if (entityPacket != null) {
+                nmsPlayer.connection.send(entityPacket);
+            }
+        } catch (Throwable failure) {
+            plugin.getSLF4JLogger().debug("Sign block restoration failed: {}", failure.getMessage());
+        }
+    }
+
+    private static void cancel(ScheduledTask task) {
+        if (task != null) task.cancel();
     }
 }

--- a/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignScreenImpl.java
+++ b/prompt-ui-26.1/src/main/java/dev/cyr1en/promptui/v26_1/SignScreenImpl.java
@@ -16,6 +16,7 @@ import org.bukkit.Material;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -134,6 +135,7 @@ public class SignScreenImpl implements SignInputScreen, Listener {
     @Override
     public void close() {
         if (!open) return;
+        HandlerList.unregisterAll(this);
         open = false;
         plugin.getSLF4JLogger().debug("SignScreen closing: player={}", player.getName());
         player.getScheduler().run(plugin, scheduledTask -> {
@@ -170,6 +172,7 @@ public class SignScreenImpl implements SignInputScreen, Listener {
 
     /** Callback from {@link SignInterceptor}: removes the virtual sign and delivers the result. */
     private void handleSignFinish(String[] lines) {
+        HandlerList.unregisterAll(this);
         open = false;
         var nmsPlayer = ((CraftPlayer) player).getHandle();
         var pipeline = nmsPlayer.connection.connection.channel.pipeline();

--- a/prompt-ui-26.2/build.gradle.kts
+++ b/prompt-ui-26.2/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("26.2.build.+")
+    paperweight.paperDevBundle("26.2.build.92-stable")
     compileOnly(project(":prompt-ui-api"))
     implementation(project(":prompt-core"))
 }

--- a/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/AnvilInventoryImpl.java
+++ b/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/AnvilInventoryImpl.java
@@ -63,25 +63,69 @@ public final class AnvilInventoryImpl extends AnvilInventory {
             throw new IllegalStateException("createInventory() must be called before open()");
         }
         var nmsPlayer = craftPlayer.getHandle();
-        nmsPlayer.connection.send(new ClientboundContainerClosePacket(0));
-        Component title = container.getTitle();
-        // containerId was already assigned in the constructor via nextContainerCounter
-        int id = container.containerId;
-        nmsPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, title));
-        nmsPlayer.containerMenu = container;
-        nmsPlayer.initMenu(container);
-        opened = true;
+        if (opened && nmsPlayer.containerMenu == container) {
+            return;
+        }
+        try {
+            closeExistingMenu(nmsPlayer);
+            Component title = container.getTitle();
+            // containerId was already assigned in the constructor via nextContainerCounter
+            int id = container.containerId;
+            nmsPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, title));
+            nmsPlayer.containerMenu = container;
+            nmsPlayer.initMenu(container);
+            opened = true;
+        } catch (RuntimeException | Error failure) {
+            opened = false;
+            restoreInventoryMenu(nmsPlayer);
+            throw failure;
+        }
     }
 
     /**
      * Closes the anvil screen using NMS packets.
      */
     public void close() {
-        if (!opened || container == null) return;
         opened = false;
+        if (container == null) return;
         var nmsPlayer = craftPlayer.getHandle();
-        nmsPlayer.connection.send(new ClientboundContainerClosePacket(container.containerId));
+        if (nmsPlayer.containerMenu == container) {
+            nmsPlayer.connection.send(new ClientboundContainerClosePacket(container.containerId));
+            nmsPlayer.doCloseContainer();
+            restoreInventoryMenu(nmsPlayer);
+        }
+    }
+
+    /** Returns whether this NMS container is currently installed for the player. */
+    public boolean isOpened() {
+        return opened;
+    }
+
+    /** Clears callbacks and parent links after the screen reaches a terminal state. */
+    public void clearCallbacks() {
+        nameChangeCallback = null;
+        if (container != null) {
+            container.setParent(null);
+        }
+    }
+
+    private void closeExistingMenu(net.minecraft.server.level.ServerPlayer nmsPlayer) {
+        var active = nmsPlayer.containerMenu;
+        if (active == null || active == nmsPlayer.inventoryMenu || active == container) {
+            return;
+        }
+        // The client must receive the id of the menu it actually has open;
+        // container id 0 is only the player's inventory menu.
+        nmsPlayer.connection.send(new ClientboundContainerClosePacket(active.containerId));
         nmsPlayer.doCloseContainer();
+        restoreInventoryMenu(nmsPlayer);
+    }
+
+    private void restoreInventoryMenu(net.minecraft.server.level.ServerPlayer nmsPlayer) {
+        if (nmsPlayer.containerMenu != nmsPlayer.inventoryMenu
+                && nmsPlayer.containerMenu == container) {
+            nmsPlayer.doCloseContainer();
+        }
     }
 
     /**

--- a/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/FrameworkAnvilScreen.java
+++ b/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/FrameworkAnvilScreen.java
@@ -4,7 +4,9 @@ import dev.cyr1en.promptui.AnvilInputScreen;
 import dev.cyr1en.promptui.ComponentUtil;
 import dev.cyr1en.promptui.ScreenResult;
 import dev.cyr1en.promptui.gui.AnvilGui;
+import dev.cyr1en.promptui.gui.Gui;
 import dev.cyr1en.promptui.gui.GuiItem;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -33,7 +35,16 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
     private AnvilGui anvilGui;
     private AnvilInventoryImpl inventoryImpl;
     private Consumer<ScreenResult> callback;
-    private boolean open;
+    private Consumer<Throwable> openFailure;
+    private ScheduledTask openTask;
+    private State state = State.NEW;
+
+    private enum State {
+        NEW,
+        CLOSED,
+        OPENING,
+        OPEN
+    }
 
     public FrameworkAnvilScreen(@NotNull JavaPlugin plugin, @NotNull Player player,
                                  @NotNull String displayText) {
@@ -53,52 +64,79 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
      */
     @Override
     public void open() {
-        player.getScheduler().run(plugin, scheduledTask -> {
+        synchronized (this) {
+            if (state != State.NEW) return;
+            state = State.OPENING;
+        }
+
+        ScheduledTask scheduled;
+        try {
+            scheduled = player.getScheduler().run(plugin, ignored -> openOnPlayerThread(),
+                    () -> failOpen(new IllegalStateException("Player scheduler retired")));
+        } catch (Throwable failure) {
+            failOpen(failure);
+            return;
+        }
+        synchronized (this) {
+            if (state == State.OPENING) {
+                openTask = scheduled;
+            } else if (scheduled != null) {
+                scheduled.cancel();
+            }
+        }
+        if (scheduled == null) {
+            failOpen(new IllegalStateException("Player scheduler returned no task"));
+        }
+    }
+
+    private void openOnPlayerThread() {
+        synchronized (this) {
+            if (state != State.OPENING) return;
+            openTask = null;
+        }
+        try {
             inventoryImpl = new AnvilInventoryImpl(player);
             anvilGui = new AnvilGui(plugin, inventoryImpl);
 
-            // Configure title
             configureTitle();
-            // Set up items
             setupItems();
 
-            // Register callbacks
-            anvilGui.setOnClose(event -> {
-                if (open) {
-                    open = false;
-                    if (callback != null) {
-                        callback.accept(ScreenResult.cancel());
-                    }
-                }
-            });
-
-            // Prevent item theft from anvil slots
+            anvilGui.setOnClose(event -> complete(ScreenResult.cancel(), false));
             anvilGui.setOnTopClick(event -> event.setCancelled(true));
-
-            // Direct result-click callback (bypasses UUID matching since NMS
-            // overwrites the result ItemStack, stripping the UUID tag)
             anvilGui.setOnResultClick(event -> {
-                if (!open) return;
-                open = false;
+                if (!isOpen()) return;
                 String answer = inventoryImpl.getRenameText();
                 plugin.getSLF4JLogger().debug(
                     "FrameworkAnvilScreen result: player={} answer={}",
                     player.getName(), answer);
-                if (callback != null) {
-                    callback.accept(ScreenResult.answer(answer));
-                }
-                closeInternal();
+                complete(ScreenResult.answer(answer), true);
             });
 
-            // Create the NMS container, render items via framework (UUID-tagged
-            // so GuiListener can route clicks to GuiItem actions), then open
             anvilGui.createInventory();
             anvilGui.update();
+            synchronized (this) {
+                if (state != State.OPENING) {
+                    cleanupScreen(anvilGui, inventoryImpl, false);
+                    return;
+                }
+            }
+            // The NMS packet path does not emit Bukkit's normal open event, so
+            // perform the same viewer/cache registration explicitly.
+            anvilGui.getHumanEntityCache().storeAndClear(player);
+            anvilGui.markViewer(player);
             inventoryImpl.open();
-
-            open = true;
+            synchronized (this) {
+                if (state == State.OPENING) {
+                    state = State.OPEN;
+                } else {
+                    cleanupScreen(anvilGui, inventoryImpl, false);
+                    return;
+                }
+            }
             plugin.getSLF4JLogger().debug("FrameworkAnvilScreen opened: player={}", player.getName());
-        }, null);
+        } catch (Throwable failure) {
+            failOpen(failure);
+        }
     }
 
     /**
@@ -177,13 +215,9 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
             }
 
             GuiItem cancelGuiItem = new GuiItem(cancelItem, event -> {
-                if (!open) return;
-                open = false;
+                if (!isOpen()) return;
                 plugin.getSLF4JLogger().debug("FrameworkAnvilScreen cancel: player={}", player.getName());
-                if (callback != null) {
-                    callback.accept(ScreenResult.cancel());
-                }
-                closeInternal();
+                complete(ScreenResult.cancel(), true);
             });
             anvilGui.getSecondItemComponent().addItem(cancelGuiItem, 0, 0);
         }
@@ -218,28 +252,153 @@ public final class FrameworkAnvilScreen implements AnvilInputScreen {
 
     @Override
     public void close() {
-        if (!open) return;
-        open = false;
-        closeInternal();
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            callback = null;
+            openFailure = null;
+        }
+        cancel(task);
+        scheduleCleanup(gui, impl, true);
     }
 
-    /** Schedules the NMS container close and Bukkit inventory close on the player's thread. */
-    private void closeInternal() {
-        player.getScheduler().run(plugin, scheduledTask -> {
-            if (inventoryImpl != null) {
-                inventoryImpl.close();
+    private void complete(ScreenResult result, boolean closePlayer) {
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        Consumer<ScreenResult> resultCallback;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            resultCallback = callback;
+            callback = null;
+        }
+        cancel(task);
+        try {
+            cleanupScreen(gui, impl, closePlayer);
+        } finally {
+            try {
+                if (resultCallback != null) {
+                    resultCallback.accept(result);
+                }
+            } finally {
+                cleanupScreen(gui, impl, false);
             }
-            player.closeInventory();
-        }, null);
+        }
+    }
+
+    private void failOpen(Throwable failure) {
+        AnvilGui gui;
+        AnvilInventoryImpl impl;
+        ScheduledTask task;
+        Consumer<Throwable> failureCallback;
+        synchronized (this) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            task = openTask;
+            openTask = null;
+            gui = anvilGui;
+            impl = inventoryImpl;
+            anvilGui = null;
+            inventoryImpl = null;
+            failureCallback = openFailure;
+            openFailure = null;
+            callback = null;
+        }
+        cancel(task);
+        try {
+            cleanupScreen(gui, impl, true);
+        } finally {
+            try {
+                if (failureCallback != null) {
+                    failureCallback.accept(failure);
+                }
+            } finally {
+                cleanupScreen(gui, impl, false);
+            }
+        }
+    }
+
+    private void scheduleCleanup(AnvilGui gui, AnvilInventoryImpl impl, boolean closePlayer) {
+        if (gui == null && impl == null) return;
+        try {
+            ScheduledTask task = player.getScheduler().run(
+                plugin,
+                ignored -> cleanupScreen(gui, impl, closePlayer),
+                () -> cleanupScreen(gui, impl, closePlayer));
+            if (task == null) {
+                cleanupScreen(gui, impl, closePlayer);
+            }
+        } catch (Throwable failure) {
+            cleanupScreen(gui, impl, closePlayer);
+        }
+    }
+
+    private void cleanupScreen(AnvilGui gui, AnvilInventoryImpl impl, boolean closePlayer) {
+        try {
+            if (impl != null) {
+                impl.clearCallbacks();
+                impl.close();
+            }
+        } finally {
+            if (gui != null) {
+                gui.setOnClose(null);
+                gui.setOnResultClick(null);
+                gui.setOnTopClick(null);
+                Gui.removeInventories(gui);
+                gui.getHumanEntityCache().restoreAndForget(player);
+                gui.removeViewer(player);
+                Gui.removeInventoryIfUnused(gui);
+
+                if (closePlayer && gui.getInventory() != null) {
+                    try {
+                        if (player.getOpenInventory().getTopInventory().equals(gui.getInventory())) {
+                            player.closeInventory();
+                        }
+                    } catch (RuntimeException ignored) {
+                        // Retired/disconnected players may reject inventory
+                        // access; the NMS and registry cleanup already ran.
+                    }
+                }
+            }
+        }
+    }
+
+    private static void cancel(ScheduledTask task) {
+        if (task != null) {
+            task.cancel();
+        }
     }
 
     @Override
     public boolean isOpen() {
-        return open;
+        synchronized (this) {
+            return state == State.OPEN;
+        }
     }
 
     @Override
     public void onResult(Consumer<ScreenResult> callback) {
         this.callback = callback;
+    }
+
+    @Override
+    public void onOpenFailure(Consumer<Throwable> callback) {
+        this.openFailure = callback;
     }
 }

--- a/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignInterceptor.java
+++ b/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignInterceptor.java
@@ -2,7 +2,9 @@ package dev.cyr1en.promptui.v26_2;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
@@ -20,18 +22,39 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class SignInterceptor extends MessageToMessageDecoder<Packet<?>> {
 
-    static final String HANDLER_NAME = "sign_interceptor";
-
     private final JavaPlugin plugin;
     private final Player player;
     private final BlockPos pos;
     private final Consumer<String[]> onFinish;
+    private final String handlerName;
+    private final Consumer<ScheduledTask> onFinishTask;
+    private final Consumer<Throwable> onScheduleFailure;
+    private final AtomicBoolean packetQueued = new AtomicBoolean();
 
     public SignInterceptor(JavaPlugin plugin, Player player, BlockPos pos, Consumer<String[]> onFinish) {
+        this(plugin, player, pos, "sign_interceptor_" + java.util.UUID.randomUUID(),
+                onFinish, ignored -> {}, ignored -> {});
+    }
+
+    public SignInterceptor(
+            JavaPlugin plugin,
+            Player player,
+            BlockPos pos,
+            String handlerName,
+            Consumer<String[]> onFinish,
+            Consumer<ScheduledTask> onFinishTask,
+            Consumer<Throwable> onScheduleFailure) {
         this.plugin = plugin;
         this.player = player;
         this.pos = pos;
+        this.handlerName = handlerName;
         this.onFinish = onFinish;
+        this.onFinishTask = onFinishTask;
+        this.onScheduleFailure = onScheduleFailure;
+    }
+
+    String getHandlerName() {
+        return handlerName;
     }
 
     /**
@@ -43,13 +66,25 @@ public class SignInterceptor extends MessageToMessageDecoder<Packet<?>> {
     protected void decode(ChannelHandlerContext ctx, Packet<?> packet, List<Object> out) {
         if (packet instanceof ServerboundSignUpdatePacket signPacket) {
             if (signPacket.getPos().equals(pos)) {
+                if (!packetQueued.compareAndSet(false, true)) {
+                    return;
+                }
                 var lines = signPacket.getLines();
                 plugin.getSLF4JLogger().debug("SignInterceptor intercepted packet: player={} lines={}",
                         player.getName(), String.join(", ", lines));
-                // route back to player's region thread
-                player.getScheduler().run(plugin, scheduledTask -> {
-                    onFinish.accept(lines);
-                }, null);
+                try {
+                    ScheduledTask task = player.getScheduler().run(plugin, scheduledTask -> {
+                        onFinish.accept(lines);
+                    }, null);
+                    if (task == null) {
+                        onScheduleFailure.accept(
+                                new IllegalStateException("Player scheduler returned no sign-finish task"));
+                    } else {
+                        onFinishTask.accept(task);
+                    }
+                } catch (Throwable failure) {
+                    onScheduleFailure.accept(failure);
+                }
                 // Drop matched packet so the server does not process a sign
                 // update at our (potentially far away) virtual position.
                 return;

--- a/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignScreenImpl.java
+++ b/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignScreenImpl.java
@@ -16,6 +16,7 @@ import org.bukkit.Material;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -147,6 +148,7 @@ public class SignScreenImpl implements SignInputScreen, Listener {
     @Override
     public void close() {
         if (!open) return;
+        HandlerList.unregisterAll(this);
         open = false;
         plugin.getSLF4JLogger().debug("SignScreen closing: player={}", player.getName());
         player.getScheduler().run(plugin, scheduledTask -> {
@@ -183,6 +185,7 @@ public class SignScreenImpl implements SignInputScreen, Listener {
 
     /** Callback from {@link SignInterceptor}: removes the virtual sign and delivers the result. */
     private void handleSignFinish(String[] lines) {
+        HandlerList.unregisterAll(this);
         open = false;
         var nmsPlayer = ((CraftPlayer) player).getHandle();
         var pipeline = nmsPlayer.connection.connection.channel.pipeline();

--- a/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignScreenImpl.java
+++ b/prompt-ui-26.2/src/main/java/dev/cyr1en/promptui/v26_2/SignScreenImpl.java
@@ -2,14 +2,18 @@ package dev.cyr1en.promptui.v26_2;
 
 import dev.cyr1en.promptui.ScreenResult;
 import dev.cyr1en.promptui.SignInputScreen;
+import io.netty.channel.ChannelPipeline;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Material;
@@ -21,151 +25,182 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
-/**
- * NMS implementation of {@link SignInputScreen} that opens a virtual sign editor
- * for text input without placing a real block.
- *
- * <p>Sends a fake sign block state and block-entity data packet to the client, then
- * installs a {@link SignInterceptor} in the player's channel pipeline to capture
- * the sign-edit response. The virtual sign is always placed behind the player
- * so it stays hidden.</p>
- */
+/** NMS implementation of {@link SignInputScreen} for a virtual sign editor. */
 public class SignScreenImpl implements SignInputScreen, Listener {
 
     private final JavaPlugin plugin;
     private final Player player;
     private final String[] defaultLines;
+    private final String handlerName = "commandprompter_sign_" + UUID.randomUUID();
+    private final Object lifecycleLock = new Object();
     private BlockPos pos;
     private SignInterceptor interceptor;
     private Map<String, String> config = Map.of();
-    private boolean open;
     private Consumer<ScreenResult> callback;
+    private Consumer<Throwable> openFailure;
+    private ScheduledTask openTask;
+    private ScheduledTask finishTask;
+    private BlockState originalBlockState;
+    private Packet<?> originalBlockEntityPacket;
+    private boolean fakeStateSent;
+    private State state = State.NEW;
+
+    private enum State { NEW, OPENING, OPEN, CLOSED }
 
     public SignScreenImpl(JavaPlugin plugin, Player player, String[] lines) {
         this.plugin = plugin;
         this.player = player;
-        this.defaultLines = lines;
-        // Position is resolved at open() time (not here) so it tracks the
-        // player's current location when the sign actually shows, and so the
-        // scheduled task can compute the eye-line position.
+        this.defaultLines = lines.clone();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
-    /**
-     * Computes the block 3 blocks behind the player at eye level. The sign
-     * is always in a loaded chunk, at a valid Y coordinate within the build
-     * limits, and (because the player is looking forward) hidden behind them.
-     * This matches the SignGUI reference implementation and avoids the
-     * out-of-bounds drop that breaks the editor-open packet when the sign
-     * is placed above the build ceiling.
-     */
     private BlockPos resolveSignPosition() {
         var eye = player.getEyeLocation();
         var dir = eye.getDirection();
         var x = eye.getBlockX() - (int) Math.round(dir.getX() * 3.0);
         var y = eye.getBlockY();
         var z = eye.getBlockZ() - (int) Math.round(dir.getZ() * 3.0);
+        int minY = player.getWorld().getMinHeight();
+        int maxY = player.getWorld().getMaxHeight() - 1;
+        y = Math.max(minY, Math.min(maxY, y));
         return new BlockPos(x, y, z);
     }
 
-    /** {@inheritDoc} */
     @Override
     public void configure(Map<String, String> config) {
         this.config = new HashMap<>(config);
     }
 
-    /**
-     * Opens the virtual sign editor on the player's thread: resolves a hidden
-     * position, sends fake block/entity packets, opens the sign GUI, and
-     * installs a {@link SignInterceptor} to capture the response.
-     */
     @Override
     public void open() {
-        player.getScheduler().run(plugin, scheduledTask -> {
+        synchronized (lifecycleLock) {
+            if (state != State.NEW) return;
+            state = State.OPENING;
+        }
+        ScheduledTask scheduled;
+        try {
+            scheduled = player.getScheduler().run(plugin, ignored -> openOnPlayerThread(),
+                    () -> failOpen(new IllegalStateException("Player scheduler retired")));
+        } catch (Throwable failure) {
+            failOpen(failure);
+            return;
+        }
+        synchronized (lifecycleLock) {
+            if (state == State.OPENING) {
+                openTask = scheduled;
+            } else if (scheduled != null) {
+                scheduled.cancel();
+            }
+        }
+        if (scheduled == null) {
+            failOpen(new IllegalStateException("Player scheduler returned no task"));
+        }
+    }
+
+    private void openOnPlayerThread() {
+        synchronized (lifecycleLock) {
+            if (state != State.OPENING) return;
+            openTask = null;
+        }
+        try {
             var nmsPlayer = ((CraftPlayer) player).getHandle();
             pos = resolveSignPosition();
+            originalBlockState = nmsPlayer.level().getBlockState(pos);
+            BlockEntity originalEntity = nmsPlayer.level().getBlockEntity(pos);
+            originalBlockEntityPacket = originalEntity == null
+                    ? null
+                    : originalEntity.getUpdatePacket();
 
             var signState = resolveSignState();
             var signEntity = new SignBlockEntity(pos, signState);
-            // Build text while level is null. SignBlockEntity.setText() calls
-            // setChanged(), which no-ops when level == null — keeping level
-            // unset here prevents the chunk at our virtual position from
-            // being marked dirty/saved.
             var text = signEntity.getText(true);
             for (int i = 0; i < Math.min(defaultLines.length, 4); i++) {
-                text = text.setMessage(i, Component.literal(defaultLines[i] != null ? defaultLines[i] : ""));
+                text = text.setMessage(i, Component.literal(
+                        defaultLines[i] != null ? defaultLines[i] : ""));
             }
             signEntity.setText(text, true);
 
-            // getUpdatePacket() needs the level to resolve registryAccess()
-            // for the block-entity data packet. Borrow the player's level for
-            // just this one packet and release it immediately — the sign
-            // block entity never actually lives in any chunk.
-            //
-            // Order matches SignGUI's Mojang wrappers: first tell the client
-            // the block at `pos` is a sign, then send the block-entity data
-            // (text), then open the editor. The client needs the block-state
-            // packet before the BE-data packet, or the editor won't open.
             var signLocation = new org.bukkit.Location(
                     player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
             player.sendBlockChange(signLocation, resolveSignMaterial().createBlockData());
+            fakeStateSent = true;
             signEntity.setLevel(nmsPlayer.level());
             try {
                 nmsPlayer.connection.send(signEntity.getUpdatePacket());
             } finally {
                 signEntity.setLevel(null);
             }
-            nmsPlayer.connection.send(new ClientboundOpenSignEditorPacket(pos, true));
 
-            var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-            if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-                pipeline.remove(SignInterceptor.HANDLER_NAME);
+            ChannelPipeline pipeline = nmsPlayer.connection.connection.channel.pipeline();
+            if (pipeline == null || pipeline.get("decoder") == null) {
+                throw new IllegalStateException("Player connection decoder is unavailable");
             }
-            interceptor = new SignInterceptor(plugin, player, pos, this::handleSignFinish);
-            pipeline.addAfter("decoder", SignInterceptor.HANDLER_NAME, interceptor);
-
-            open = true;
+            interceptor = new SignInterceptor(
+                    plugin, player, pos, handlerName, this::handleSignFinish,
+                    this::rememberFinishTask, this::failOpen);
+            pipeline.addAfter("decoder", handlerName, interceptor);
+            synchronized (lifecycleLock) {
+                if (state != State.OPENING) {
+                    cleanupScreen(false);
+                    return;
+                }
+                state = State.OPEN;
+            }
+            nmsPlayer.connection.send(new ClientboundOpenSignEditorPacket(pos, true));
             plugin.getSLF4JLogger().debug("SignScreen opened: player={} lines={} pos={}",
                     player.getName(), defaultLines.length, pos);
-        }, null);
+        } catch (Throwable failure) {
+            failOpen(failure);
+        }
     }
 
-    /** Converts the configured sign material to its default NMS {@link BlockState}. */
+    private void rememberFinishTask(ScheduledTask task) {
+        synchronized (lifecycleLock) {
+            if (state == State.OPEN || state == State.OPENING) {
+                finishTask = task;
+                return;
+            }
+        }
+        task.cancel();
+    }
+
     private BlockState resolveSignState() {
         var nmsBlock = org.bukkit.craftbukkit.block.CraftBlockType
                 .bukkitToMinecraft(resolveSignMaterial());
         return nmsBlock.defaultBlockState();
     }
 
-    /** Resolves the sign {@link Material} from config, defaulting to {@link Material#OAK_SIGN}. */
     private Material resolveSignMaterial() {
         var materialName = config.getOrDefault("signMaterial", "OAK_SIGN");
         var mat = Material.matchMaterial(materialName);
         return mat != null ? mat : Material.OAK_SIGN;
     }
 
-    /** Removes the {@link SignInterceptor} from the pipeline and restores the virtual block to air. */
     @Override
     public void close() {
-        if (!open) return;
+        ScheduledTask open;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            open = openTask;
+            finish = finishTask;
+            openTask = null;
+            finishTask = null;
+            callback = null;
+            openFailure = null;
+        }
+        cancel(open);
+        cancel(finish);
         HandlerList.unregisterAll(this);
-        open = false;
-        plugin.getSLF4JLogger().debug("SignScreen closing: player={}", player.getName());
-        player.getScheduler().run(plugin, scheduledTask -> {
-            var nmsPlayer = ((CraftPlayer) player).getHandle();
-            var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-            if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-                pipeline.remove(SignInterceptor.HANDLER_NAME);
-            }
-            interceptor = null;
-            // Remove fake sign entity from client view
-            nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(pos, Blocks.AIR.defaultBlockState()));
-        }, null);
+        scheduleCleanup(false, null);
     }
 
     @Override
     public boolean isOpen() {
-        return open;
+        synchronized (lifecycleLock) {
+            return state == State.OPEN;
+        }
     }
 
     @Override
@@ -173,37 +208,137 @@ public class SignScreenImpl implements SignInputScreen, Listener {
         this.callback = callback;
     }
 
-    /** Cleans up the sign screen if the player disconnects while it is open. */
+    @Override
+    public void onOpenFailure(Consumer<Throwable> callback) {
+        this.openFailure = callback;
+    }
+
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
-        if (event.getPlayer().equals(player)) {
-            plugin.getSLF4JLogger().debug("SignScreen player quit cleanup: player={}",
-                    player.getName());
-            close();
+        if (event.getPlayer().equals(player)) close();
+    }
+
+    private void handleSignFinish(String[] lines) {
+        Consumer<ScreenResult> resultCallback;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state != State.OPEN) return;
+            state = State.CLOSED;
+            finish = finishTask;
+            finishTask = null;
+            resultCallback = callback;
+            callback = null;
+        }
+        cancel(finish);
+        HandlerList.unregisterAll(this);
+        String answer = String.join("\n", lines == null ? new String[0] : lines).trim();
+        ScreenResult result = answer.isEmpty()
+                ? ScreenResult.cancel() : ScreenResult.answer(answer);
+        try {
+            cleanupScreen(true);
+        } finally {
+            try {
+                if (resultCallback != null) resultCallback.accept(result);
+            } finally {
+                cleanupScreen(false);
+            }
         }
     }
 
-    /** Callback from {@link SignInterceptor}: removes the virtual sign and delivers the result. */
-    private void handleSignFinish(String[] lines) {
-        HandlerList.unregisterAll(this);
-        open = false;
-        var nmsPlayer = ((CraftPlayer) player).getHandle();
-        var pipeline = nmsPlayer.connection.connection.channel.pipeline();
-        if (pipeline.get(SignInterceptor.HANDLER_NAME) != null) {
-            pipeline.remove(SignInterceptor.HANDLER_NAME);
+    private void failOpen(Throwable failure) {
+        Consumer<Throwable> failureCallback;
+        ScheduledTask open;
+        ScheduledTask finish;
+        synchronized (lifecycleLock) {
+            if (state == State.CLOSED) return;
+            state = State.CLOSED;
+            open = openTask;
+            finish = finishTask;
+            openTask = null;
+            finishTask = null;
+            failureCallback = openFailure;
+            openFailure = null;
+            callback = null;
         }
-        interceptor = null;
-        nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(pos, Blocks.AIR.defaultBlockState()));
-        player.closeInventory();
-        var answer = String.join("\n", lines).trim();
-        plugin.getSLF4JLogger().debug("SignScreen finished: player={} answer={}",
-                player.getName(), answer);
-        if (callback != null) {
-            if (answer.isEmpty()) {
-                callback.accept(ScreenResult.cancel());
-            } else {
-                callback.accept(ScreenResult.answer(answer));
+        cancel(open);
+        cancel(finish);
+        HandlerList.unregisterAll(this);
+        scheduleCleanup(false, failureCallback == null ? null : () -> failureCallback.accept(failure));
+    }
+
+    private void scheduleCleanup(boolean closeInventory, Runnable afterCleanup) {
+        try {
+            ScheduledTask task = player.getScheduler().run(
+                    plugin, ignored -> terminalCleanup(closeInventory, afterCleanup),
+                    () -> terminalCleanup(closeInventory, afterCleanup));
+            if (task == null) terminalCleanup(closeInventory, afterCleanup);
+        } catch (Throwable failure) {
+            terminalCleanup(closeInventory, afterCleanup);
+        }
+    }
+
+    private void terminalCleanup(boolean closeInventory, Runnable afterCleanup) {
+        try {
+            cleanupScreen(closeInventory);
+        } finally {
+            if (afterCleanup != null) {
+                try {
+                    afterCleanup.run();
+                } finally {
+                    cleanupScreen(false);
+                }
             }
         }
+    }
+
+    private void cleanupScreen(boolean closeInventory) {
+        SignInterceptor current = interceptor;
+        interceptor = null;
+        HandlerList.unregisterAll(this);
+        try {
+            var nmsPlayer = ((CraftPlayer) player).getHandle();
+            if (nmsPlayer.connection != null && nmsPlayer.connection.connection != null) {
+                ChannelPipeline pipeline = nmsPlayer.connection.connection.channel.pipeline();
+                if (pipeline != null && current != null && pipeline.get(handlerName) == current) {
+                    pipeline.remove(handlerName);
+                }
+            }
+        } catch (Throwable failure) {
+            plugin.getSLF4JLogger().debug("Sign pipeline cleanup failed: {}", failure.getMessage());
+        } finally {
+            restoreClientState();
+            if (closeInventory) {
+                try {
+                    player.closeInventory();
+                } catch (Throwable failure) {
+                    plugin.getSLF4JLogger().debug("Sign inventory cleanup failed: {}", failure.getMessage());
+                }
+            }
+        }
+    }
+
+    private void restoreClientState() {
+        BlockPos restorePos;
+        BlockState restoreState;
+        Packet<?> entityPacket;
+        synchronized (lifecycleLock) {
+            if (!fakeStateSent || pos == null) return;
+            fakeStateSent = false;
+            restorePos = pos;
+            restoreState = originalBlockState;
+            entityPacket = originalBlockEntityPacket;
+        }
+        try {
+            var nmsPlayer = ((CraftPlayer) player).getHandle();
+            if (restoreState == null) restoreState = nmsPlayer.level().getBlockState(restorePos);
+            nmsPlayer.connection.send(new ClientboundBlockUpdatePacket(restorePos, restoreState));
+            if (entityPacket != null) nmsPlayer.connection.send(entityPacket);
+        } catch (Throwable failure) {
+            plugin.getSLF4JLogger().debug("Sign block restoration failed: {}", failure.getMessage());
+        }
+    }
+
+    private static void cancel(ScheduledTask task) {
+        if (task != null) task.cancel();
     }
 }

--- a/prompt-ui-api/build.gradle.kts
+++ b/prompt-ui-api/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:26.1.2.build.+")
+    compileOnly("io.papermc.paper:paper-api:26.1.2.build.74-stable")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testImplementation("net.kyori:adventure-api:4.26.1")

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/InputScreen.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/InputScreen.java
@@ -38,4 +38,16 @@ public interface InputScreen {
      * @param callback invoked once with the result, then discarded
      */
     void onResult(Consumer<ScreenResult> callback);
+
+    /**
+     * Registers an optional callback for failures that occur after
+     * {@link #open()} has scheduled platform work. Existing implementations may
+     * ignore this hook; NMS-backed screens use it so wrappers can fall back to
+     * chat without leaving a half-open screen.
+     *
+     * @param callback invoked at most once when asynchronous opening fails
+     */
+    default void onOpenFailure(Consumer<Throwable> callback) {
+        // Optional lifecycle extension for backwards-compatible providers.
+    }
 }

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/ChestGui.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/ChestGui.java
@@ -14,15 +14,13 @@ import java.util.List;
 /**
  * A chest-style GUI with 1-6 rows.
  *
- * <p>Uses a single merged {@link GuiComponent} that spans both the chest rows
- * and the player inventory rows below. The component is split at render time
- * via row exclusion.</p>
+ * <p>The component covers the chest rows only. Player-inventory rows are not
+ * advertised until they have a real renderer; bottom-inventory interaction is
+ * disabled by default rather than silently exposing an unrendered component.</p>
  */
 public final class ChestGui extends NamedGui implements MergedGui, InventoryBased, InventoryHolder {
 
     private static final int ROW_WIDTH = 9;
-    private static final int PLAYER_INV_ROWS = 4; // 36 slots = hotbar (1 row) + storage (3 rows)
-
     private final int rows;
     private final GuiComponent guiComponent;
 
@@ -38,7 +36,8 @@ public final class ChestGui extends NamedGui implements MergedGui, InventoryBase
             throw new IllegalArgumentException("Chest rows must be 1-6, got " + rows);
         }
         this.rows = rows;
-        this.guiComponent = new GuiComponent(ROW_WIDTH, rows + PLAYER_INV_ROWS);
+        this.guiComponent = new GuiComponent(ROW_WIDTH, rows);
+        setPlayerInventoryUsed(false);
     }
 
     // -- InventoryBased --
@@ -89,9 +88,6 @@ public final class ChestGui extends NamedGui implements MergedGui, InventoryBase
 
         guiComponent.placeItems(inventory, 0, 0);
 
-        if (isPlayerInventoryUsed()) {
-            // TODO: Render component's player inventory rows into player's actual inventory.
-        }
     }
 
     /**

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/Gui.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/Gui.java
@@ -11,10 +11,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
 /**
@@ -22,13 +23,17 @@ import java.util.function.Consumer;
  *
  * <p>Provides the core lifecycle ({@link #show}, {@link #update}, {@link #click}),
  * event callbacks, and a static registry mapping {@link Inventory} instances to
- * their owning {@link Gui}. The registry uses a {@link WeakHashMap} to work around
- * Bukkit's refusal to set {@link InventoryHolder} on certain inventory types (e.g., anvils).</p>
+ * their owning {@link Gui}. The registry is explicit because Bukkit refuses to
+ * set {@link InventoryHolder} on certain inventory types (e.g., anvils). Entries
+ * are removed when the last viewer closes the inventory.</p>
  */
 public abstract class Gui {
 
     /** Maps inventories to their owning Gui, bypassing Holder limitations. */
-    protected static final Map<Inventory, Gui> GUI_INVENTORIES = new WeakHashMap<>();
+    protected static final ConcurrentMap<Inventory, Gui> GUI_INVENTORIES = new ConcurrentHashMap<>();
+
+    /** GUIs with at least one currently tracked viewer. */
+    private static final Set<Gui> ACTIVE_GUIS = ConcurrentHashMap.newKeySet();
 
     /** The singleton event listener, created lazily on first Gui construction. */
     private static GuiListener listener;
@@ -36,6 +41,7 @@ public abstract class Gui {
     protected final JavaPlugin plugin;
     protected Inventory inventory;
     protected final HumanEntityCache humanEntityCache = new HumanEntityCache();
+    private final Set<HumanEntity> viewers = ConcurrentHashMap.newKeySet();
 
     // -- event callbacks --
     private Consumer<InventoryClickEvent> onTopClick;
@@ -66,10 +72,34 @@ public abstract class Gui {
      * then opens the inventory. Subclasses must call {@code super.show(humanEntity)}
      * after preparing the inventory.
      */
-    public void show(@NotNull HumanEntity humanEntity) {
-        humanEntityCache.storeAndClear(humanEntity);
-        if (inventory != null) {
-            humanEntity.openInventory(inventory);
+    public synchronized void show(@NotNull HumanEntity humanEntity) {
+        if (inventory == null) {
+            return;
+        }
+
+        // Re-register on every open because a final close removes the explicit
+        // association and anvil inventories cannot rely on their holder.
+        addInventory(inventory, this);
+        boolean wasViewer = isViewer(humanEntity);
+        boolean stored = false;
+        try {
+            stored = humanEntityCache.storeAndClear(humanEntity);
+            // Paper returns null when opening is cancelled or the inventory is
+            // otherwise not viewable. Treat it like an exception so the
+            // player's original inventory is never lost.
+            if (humanEntity.openInventory(inventory) == null) {
+                throw new IllegalStateException("Inventory opening was cancelled");
+            }
+            markViewer(humanEntity);
+        } catch (RuntimeException | Error failure) {
+            if (stored) {
+                humanEntityCache.restoreAndForget(humanEntity);
+            }
+            if (!wasViewer) {
+                removeViewer(humanEntity);
+            }
+            removeInventoryIfUnused(this);
+            throw failure;
         }
     }
 
@@ -213,7 +243,31 @@ public abstract class Gui {
      * Registers a gui-inventory association. Called when inventory is created.
      */
     public static void addInventory(@NotNull Inventory inventory, @NotNull Gui gui) {
-        GUI_INVENTORIES.put(inventory, gui);
+        synchronized (gui) {
+            GUI_INVENTORIES.put(inventory, gui);
+        }
+    }
+
+    /**
+     * Removes an inventory association if it still belongs to the supplied GUI.
+     * The conditional form prevents an old GUI from removing a newer mapping.
+     */
+    public static void removeInventory(@NotNull Inventory inventory, @NotNull Gui gui) {
+        synchronized (gui) {
+            GUI_INVENTORIES.remove(inventory, gui);
+        }
+    }
+
+    /** Removes an inventory association without requiring the owning GUI. */
+    public static void removeInventory(@NotNull Inventory inventory) {
+        GUI_INVENTORIES.remove(inventory);
+    }
+
+    /** Removes every inventory association owned by the supplied GUI. */
+    public static void removeInventories(@NotNull Gui gui) {
+        synchronized (gui) {
+            GUI_INVENTORIES.entrySet().removeIf(entry -> entry.getValue() == gui);
+        }
     }
 
     /**
@@ -235,6 +289,69 @@ public abstract class Gui {
      */
     @NotNull
     public static Set<Gui> getGuis() {
-        return new HashSet<>(GUI_INVENTORIES.values());
+        return Collections.unmodifiableSet(new HashSet<>(GUI_INVENTORIES.values()));
+    }
+
+    /** Returns a stable snapshot of GUIs that currently have viewers. */
+    @NotNull
+    public static Set<Gui> getActiveGuis() {
+        return Collections.unmodifiableSet(new HashSet<>(ACTIVE_GUIS));
+    }
+
+    /** Marks a viewer as active for this GUI. */
+    public synchronized void markViewer(@NotNull HumanEntity humanEntity) {
+        viewers.add(humanEntity);
+        ACTIVE_GUIS.add(this);
+    }
+
+    /** Removes a viewer and reports whether no viewers remain. */
+    public synchronized boolean removeViewer(@NotNull HumanEntity humanEntity) {
+        viewers.remove(humanEntity);
+        if (viewers.isEmpty()) {
+            ACTIVE_GUIS.remove(this);
+            return true;
+        }
+        return false;
+    }
+
+    /** Removes all tracked viewers from this GUI's active state. */
+    public synchronized void removeViewerAll() {
+        viewers.clear();
+        ACTIVE_GUIS.remove(this);
+    }
+
+    /** Returns whether the supplied entity is an active viewer of this GUI. */
+    public synchronized boolean isViewer(@NotNull HumanEntity humanEntity) {
+        return viewers.contains(humanEntity);
+    }
+
+    /** Returns whether at least one viewer is currently active. */
+    public synchronized boolean hasViewers() {
+        return !viewers.isEmpty();
+    }
+
+    /** Returns a stable snapshot of this GUI's active viewers. */
+    @NotNull
+    public synchronized Set<HumanEntity> getViewers() {
+        return Collections.unmodifiableSet(new HashSet<>(viewers));
+    }
+
+    /**
+     * Removes this GUI from the explicit registry only after its final viewer
+     * has gone away.
+     */
+    public static void removeInventoryIfUnused(@NotNull Gui gui) {
+        synchronized (gui) {
+            if (!gui.hasViewers()) {
+                GUI_INVENTORIES.entrySet().removeIf(entry -> entry.getValue() == gui);
+                ACTIVE_GUIS.remove(gui);
+            }
+        }
+    }
+
+    /** Clears the global registry and active set after viewer restoration. */
+    public static void clearRegistry() {
+        GUI_INVENTORIES.clear();
+        ACTIVE_GUIS.clear();
     }
 }

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiComponent.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiComponent.java
@@ -131,10 +131,15 @@ public final class GuiComponent {
     public boolean click(@NotNull Gui gui, @NotNull InventoryClickEvent event, int rawSlot) {
         Slot slot = slotFromRaw(rawSlot);
         if (slot == null) return false;
-        // Try panes in reverse priority (foreground first)
-        for (int i = panes.size() - 1; i >= 0; i--) {
-            PositionedPane pp = panes.get(i);
-            if (!pp.pane().isVisible()) continue;
+        // Rendering sorts low priorities first and lets later panes overwrite
+        // earlier cells. Route clicks through that exact rendered order in
+        // reverse so the visible foreground pane receives the event first.
+        List<PositionedPane> renderedPanes = panes.stream()
+            .filter(pp -> pp.pane().isVisible())
+            .sorted()
+            .toList();
+        for (int i = renderedPanes.size() - 1; i >= 0; i--) {
+            PositionedPane pp = renderedPanes.get(i);
             // Translate to pane-local coordinates
             int localX = slot.x() - pp.offset().x();
             int localY = slot.y() - pp.offset().y();

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiListener.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiListener.java
@@ -128,11 +128,13 @@ public final class GuiListener implements Listener {
         Gui gui = Gui.getGui(event.getInventory());
         if (gui == null) return;
 
-        gui.callOnClose(event);
-        activeGuis.remove(gui);
-
-        HumanEntity player = event.getPlayer();
-        gui.getHumanEntityCache().restoreAndForget(player);
+        try {
+            gui.callOnClose(event);
+        } finally {
+            activeGuis.remove(gui);
+            HumanEntity player = event.getPlayer();
+            gui.getHumanEntityCache().restoreAndForget(player);
+        }
     }
 
     // -- Entity Pickup Item --
@@ -146,9 +148,11 @@ public final class GuiListener implements Listener {
         if (!(event.getEntity() instanceof HumanEntity player)) return;
         for (Gui gui : activeGuis) {
             if (gui.getHumanEntityCache().contains(player)) {
-                gui.getHumanEntityCache().add(player, event.getItem().getItemStack());
-                event.getItem().remove();
-                event.setCancelled(true);
+                boolean stored = gui.getHumanEntityCache().add(player, event.getItem().getItemStack());
+                if (stored) {
+                    event.getItem().remove();
+                    event.setCancelled(true);
+                }
                 break;
             }
         }

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiListener.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/GuiListener.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Central event handler for all GUI lifecycle events.
@@ -27,7 +28,7 @@ import java.util.Set;
 public final class GuiListener implements Listener {
 
     private final JavaPlugin plugin;
-    private final Set<Gui> activeGuis = new HashSet<>();
+    private final Set<Gui> activeGuis = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates and registers this listener with the Bukkit plugin manager.
@@ -45,7 +46,8 @@ public final class GuiListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onInventoryOpen(@NotNull InventoryOpenEvent event) {
         Gui gui = Gui.getGui(event.getInventory());
-        if (gui != null) {
+        if (gui != null && !event.isCancelled()) {
+            gui.markViewer(event.getPlayer());
             activeGuis.add(gui);
         }
     }
@@ -113,7 +115,7 @@ public final class GuiListener implements Listener {
         }
 
         // Cancel drag on top inventory to prevent item movement
-        if (touchesTop) {
+        if (touchesTop || (touchesBottom && !gui.isPlayerInventoryUsed())) {
             event.setCancelled(true);
         }
     }
@@ -128,12 +130,27 @@ public final class GuiListener implements Listener {
         Gui gui = Gui.getGui(event.getInventory());
         if (gui == null) return;
 
+        HumanEntity player = event.getPlayer();
+        boolean lastViewer = gui.removeViewer(player);
+        gui.getHumanEntityCache().restoreAndForget(player);
+        if (lastViewer) {
+            activeGuis.remove(gui);
+            Gui.removeInventories(gui);
+        }
+
         try {
             gui.callOnClose(event);
         } finally {
-            activeGuis.remove(gui);
-            HumanEntity player = event.getPlayer();
-            gui.getHumanEntityCache().restoreAndForget(player);
+            // Close callbacks are user code and may open the next prompt. The
+            // registry/cache cleanup deliberately happens before the callback,
+            // while this finally block makes the cleanup idempotent if the
+            // callback throws or a second close event is emitted.
+            if (!gui.isViewer(player)) {
+                gui.removeViewer(player);
+                gui.getHumanEntityCache().restoreAndForget(player);
+                Gui.removeInventoryIfUnused(gui);
+                activeGuis.remove(gui);
+            }
         }
     }
 
@@ -146,13 +163,17 @@ public final class GuiListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityPickupItem(@NotNull EntityPickupItemEvent event) {
         if (!(event.getEntity() instanceof HumanEntity player)) return;
-        for (Gui gui : activeGuis) {
-            if (gui.getHumanEntityCache().contains(player)) {
+        for (Gui gui : Gui.getActiveGuis()) {
+            if (gui.isViewer(player) && gui.getHumanEntityCache().contains(player)) {
                 boolean stored = gui.getHumanEntityCache().add(player, event.getItem().getItemStack());
                 if (stored) {
                     event.getItem().remove();
-                    event.setCancelled(true);
                 }
+                // A full snapshot is still protected: cancelling without
+                // removing leaves the world item untouched for a later,
+                // non-temporary pickup instead of allowing it into the
+                // transient inventory.
+                event.setCancelled(true);
                 break;
             }
         }
@@ -162,11 +183,30 @@ public final class GuiListener implements Listener {
      * Closes all active GUIs. Called on plugin disable.
      */
     public void closeAll() {
-        for (Gui gui : new HashSet<>(activeGuis)) {
-            for (HumanEntity viewer : new HashSet<>(gui.getInventory().getViewers())) {
-                viewer.closeInventory();
+        Set<Gui> guis = new HashSet<>(Gui.getGuis());
+        guis.addAll(Gui.getActiveGuis());
+        guis.addAll(new HashSet<>(activeGuis));
+        for (Gui gui : guis) {
+            Set<HumanEntity> viewers = new HashSet<>(gui.getViewers());
+            Inventory guiInventory = gui.getInventory();
+            if (guiInventory != null) {
+                viewers.addAll(new HashSet<>(guiInventory.getViewers()));
             }
+            for (HumanEntity viewer : viewers) {
+                try {
+                    viewer.closeInventory();
+                } finally {
+                    gui.removeViewer(viewer);
+                    gui.getHumanEntityCache().restoreAndForget(viewer);
+                }
+            }
+            // A close event is not guaranteed during plugin shutdown. Restore
+            // any cached entity not present in the platform viewer list too.
+            gui.getHumanEntityCache().restoreAll();
+            Gui.removeInventories(gui);
+            gui.removeViewerAll();
         }
         activeGuis.clear();
+        Gui.clearRegistry();
     }
 }

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/MergedGui.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/gui/MergedGui.java
@@ -6,8 +6,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 /**
- * A GUI whose top and bottom inventories are rendered as a single merged
- * {@link GuiComponent}, typically used by chest-style GUIs.
+ * A GUI whose rendered inventory region is represented by a single
+ * {@link GuiComponent}, typically used by chest-style GUIs. Implementations
+ * that do not render player-inventory rows expose only their top region rather
+ * than advertising an absent bottom component.
  */
 public interface MergedGui {
 

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/inventory/HumanEntityCache.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/inventory/HumanEntityCache.java
@@ -55,17 +55,19 @@ public final class HumanEntityCache {
      *
      * @param entity the human entity
      * @param item   the item to add to the cached inventory
+     * @return true if the item was stored, or false if the entity is not cached or the cache is full
      */
-    public void add(@NotNull HumanEntity entity, @NotNull ItemStack item) {
+    public boolean add(@NotNull HumanEntity entity, @NotNull ItemStack item) {
         ItemStack[] saved = cache.get(entity);
         if (saved != null) {
             for (int i = 0; i < 36; i++) {
                 if (saved[i] == null) {
                     saved[i] = item;
-                    return;
+                    return true;
                 }
             }
         }
+        return false;
     }
 
     /**

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/inventory/HumanEntityCache.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/inventory/HumanEntityCache.java
@@ -5,8 +5,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Caches player inventories when a GUI is shown and restores them on close.
@@ -17,21 +19,52 @@ import java.util.Map;
  */
 public final class HumanEntityCache {
 
-    private final Map<HumanEntity, ItemStack[]> cache = new HashMap<>();
+    /**
+     * The cache is accessed by inventory events and by player-affine tasks.  A
+     * concurrent map keeps the lifecycle safe when those paths happen on
+     * different region threads; the individual snapshots are synchronized when
+     * their slots are modified or restored.
+     */
+    private final Map<HumanEntity, ItemStack[]> cache = new ConcurrentHashMap<>();
 
     /**
      * Saves and clears the player's inventory (slots 0-35).
      *
      * @param entity the human entity whose inventory to cache
      */
-    public void storeAndClear(@NotNull HumanEntity entity) {
+    public synchronized boolean storeAndClear(@NotNull HumanEntity entity) {
+        /*
+         * The contains/put pair is protected by this cache's monitor. Calling
+         * show() twice for the same viewer must not replace the original
+         * snapshot with the already empty temporary inventory from the first
+         * call.
+         */
+        if (cache.containsKey(entity)) {
+            return false;
+        }
+
+        cache.put(entity, snapshotAndClear(entity));
+        return true;
+    }
+
+    private ItemStack[] snapshotAndClear(HumanEntity entity) {
         PlayerInventory inventory = entity.getInventory();
         ItemStack[] saved = new ItemStack[36];
-        for (int i = 0; i < 36; i++) {
-            saved[i] = inventory.getItem(i);
-            inventory.setItem(i, null);
+        try {
+            for (int i = 0; i < 36; i++) {
+                ItemStack item = inventory.getItem(i);
+                saved[i] = item == null ? null : item.clone();
+                inventory.setItem(i, null);
+            }
+            return saved;
+        } catch (RuntimeException | Error failure) {
+            // Do not leave a partially cleared inventory if the platform API
+            // rejects one of the slot operations.
+            for (int i = 0; i < 36; i++) {
+                inventory.setItem(i, saved[i]);
+            }
+            throw failure;
         }
-        cache.put(entity, saved);
     }
 
     /**
@@ -39,12 +72,14 @@ public final class HumanEntityCache {
      *
      * @param entity the human entity whose inventory to restore
      */
-    public void restoreAndForget(@NotNull HumanEntity entity) {
+    public synchronized void restoreAndForget(@NotNull HumanEntity entity) {
         ItemStack[] saved = cache.remove(entity);
         if (saved != null) {
-            PlayerInventory inventory = entity.getInventory();
-            for (int i = 0; i < 36; i++) {
-                inventory.setItem(i, saved[i]);
+            synchronized (saved) {
+                PlayerInventory inventory = entity.getInventory();
+                for (int i = 0; i < 36; i++) {
+                    inventory.setItem(i, saved[i]);
+                }
             }
         }
     }
@@ -57,13 +92,15 @@ public final class HumanEntityCache {
      * @param item   the item to add to the cached inventory
      * @return true if the item was stored, or false if the entity is not cached or the cache is full
      */
-    public boolean add(@NotNull HumanEntity entity, @NotNull ItemStack item) {
+    public synchronized boolean add(@NotNull HumanEntity entity, @NotNull ItemStack item) {
         ItemStack[] saved = cache.get(entity);
         if (saved != null) {
-            for (int i = 0; i < 36; i++) {
-                if (saved[i] == null) {
-                    saved[i] = item;
-                    return true;
+            synchronized (saved) {
+                for (int i = 0; i < 36; i++) {
+                    if (saved[i] == null) {
+                        saved[i] = item.clone();
+                        return true;
+                    }
                 }
             }
         }
@@ -73,8 +110,27 @@ public final class HumanEntityCache {
     /**
      * Returns whether the entity has a cached inventory.
      */
-    public boolean contains(@NotNull HumanEntity entity) {
+    public synchronized boolean contains(@NotNull HumanEntity entity) {
         return cache.containsKey(entity);
+    }
+
+    /**
+     * Returns a stable snapshot of entities with cached inventories.
+     */
+    @NotNull
+    public List<HumanEntity> getCachedEntities() {
+        return new ArrayList<>(cache.keySet());
+    }
+
+    /**
+     * Restores every cached inventory and clears the cache.  This is used by
+     * plugin-wide GUI shutdown so a close event is not required for cleanup.
+     */
+    public synchronized void restoreAll() {
+        for (HumanEntity entity : getCachedEntities()) {
+            restoreAndForget(entity);
+        }
+        cache.clear();
     }
 
     /**

--- a/prompt-ui-api/src/main/java/dev/cyr1en/promptui/pane/OutlinePane.java
+++ b/prompt-ui-api/src/main/java/dev/cyr1en/promptui/pane/OutlinePane.java
@@ -101,10 +101,20 @@ public final class OutlinePane extends Pane {
     public GuiItemContainer display() {
         GuiItemContainer container = new GuiItemContainer(getLength(), getHeight());
         Iterator<GuiItem> iterator = items.iterator();
-        for (int y = 0; y < getHeight(); y++) {
+        if (orientation == Orientation.VERTICAL) {
             for (int x = 0; x < getLength(); x++) {
-                if (iterator.hasNext() && isMaskEnabled(x, y)) {
-                    container.setItem(x, y, iterator.next());
+                for (int y = 0; y < getHeight(); y++) {
+                    if (iterator.hasNext() && isMaskEnabled(x, y)) {
+                        container.setItem(x, y, iterator.next());
+                    }
+                }
+            }
+        } else {
+            for (int y = 0; y < getHeight(); y++) {
+                for (int x = 0; x < getLength(); x++) {
+                    if (iterator.hasNext() && isMaskEnabled(x, y)) {
+                        container.setItem(x, y, iterator.next());
+                    }
                 }
             }
         }
@@ -133,16 +143,33 @@ public final class OutlinePane extends Pane {
      */
     private GuiItem getItemAt(@NotNull Slot slot) {
         Iterator<GuiItem> iterator = items.iterator();
-        for (int y = 0; y < getHeight(); y++) {
+        if (orientation == Orientation.VERTICAL) {
             for (int x = 0; x < getLength(); x++) {
-                if (isMaskEnabled(x, y)) {
-                    if (iterator.hasNext()) {
-                        GuiItem item = iterator.next();
-                        if (x == slot.x() && y == slot.y()) {
-                            return item;
+                for (int y = 0; y < getHeight(); y++) {
+                    if (isMaskEnabled(x, y)) {
+                        if (iterator.hasNext()) {
+                            GuiItem item = iterator.next();
+                            if (x == slot.x() && y == slot.y()) {
+                                return item;
+                            }
+                        } else {
+                            return null;
                         }
-                    } else {
-                        return null;
+                    }
+                }
+            }
+        } else {
+            for (int y = 0; y < getHeight(); y++) {
+                for (int x = 0; x < getLength(); x++) {
+                    if (isMaskEnabled(x, y)) {
+                        if (iterator.hasNext()) {
+                            GuiItem item = iterator.next();
+                            if (x == slot.x() && y == slot.y()) {
+                                return item;
+                            }
+                        } else {
+                            return null;
+                        }
                     }
                 }
             }

--- a/schema/presets.schema.json
+++ b/schema/presets.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CommandPrompter JSON Configuration",
+  "description": "Documentation schema for presets.json. The runtime currently does not validate this file against JSON Schema.",
   "type": "object",
   "additionalProperties": false,
   "required": ["prompts", "post_commands"],
@@ -26,6 +27,17 @@
     }
   },
   "$defs": {
+    "titleDisplay": {
+      "type": "object",
+      "description": "Optional Adventure title wrapper used by every prompt record.",
+      "additionalProperties": false,
+      "required": ["main"],
+      "properties": {
+        "main": { "type": "string" },
+        "sub": { "type": ["string", "null"] },
+        "ticks": { "type": ["integer", "null"] }
+      }
+    },
     "cancelBehavior": {
       "type": "object",
       "additionalProperties": false,
@@ -71,6 +83,7 @@
         "id": { "type": "string", "minLength": 1 },
         "prompt_text": { "type": "string", "minLength": 1 },
         "sanitize": { "type": "boolean", "default": true },
+        "title_display": { "$ref": "#/$defs/titleDisplay" },
         "cancel": { "$ref": "#/$defs/cancelBehavior" }
       }
     },
@@ -84,6 +97,7 @@
         "title": { "type": "string", "minLength": 1 },
         "prompt_text": { "type": "string", "minLength": 1 },
         "sanitize": { "type": "boolean", "default": true },
+        "title_display": { "$ref": "#/$defs/titleDisplay" },
         "left_button": { "$ref": "#/$defs/anvilButton" },
         "right_button": { "$ref": "#/$defs/anvilButton" }
       }
@@ -97,6 +111,7 @@
         "id": { "type": "string", "minLength": 1 },
         "prompt_text": { "type": "string", "minLength": 1 },
         "sanitize": { "type": "boolean", "default": true },
+        "title_display": { "$ref": "#/$defs/titleDisplay" },
         "filter": { "type": "string" },
         "cancel_button": { "$ref": "#/$defs/uiButton" },
         "previous_button": { "$ref": "#/$defs/uiButton" },
@@ -112,6 +127,7 @@
         "id": { "type": "string", "minLength": 1 },
         "prompt_text": { "type": "string", "minLength": 1 },
         "sanitize": { "type": "boolean", "default": true },
+        "title_display": { "$ref": "#/$defs/titleDisplay" },
         "default_lines": { 
           "type": "array", 
           "items": { "type": "string" },
@@ -205,6 +221,7 @@
         "id": { "type": "string", "minLength": 1 },
         "title": { "type": "string", "minLength": 1 },
         "sanitize": { "type": "boolean", "default": true },
+        "title_display": { "$ref": "#/$defs/titleDisplay" },
         "base": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
## Summary

- harden parser, configuration, session, permission, hook, and post-command handling based on the full code audit
- improve Folia-safe teardown and UI/NMS lifecycle behavior across Paper 26.1 and 26.2
- package both versioned screen providers correctly and notify active players when reload cancels their prompts
- strengthen release validation and bump the plugin version to 3.1.1

## Commits

- `a1496f6` resolve privilege escalation, parser, dialog, and listener leak bugs
- `3de8926` harden runtime and configuration handling
- `dc6b32e` package all versioned screen providers
- `0742643` notify players when reload cancels prompts
- `1050a3d` bump version to 3.1.1

## Verification

- `./gradlew clean build printVersion`
- Gradle reported version `3.1.1`
- shaded artifact: `CommandPrompterPaper-3.1.1.jar`
- embedded `paper-plugin.yml` reports version `3.1.1`
- screen-provider service descriptor contains both 26.1 and 26.2 implementations