### PR TITLE
Default promptpaper.cancel permission to true so non-operators can cancel their own prompt

### DIFF
--- a/prompt-paper/src/main/resources/paper-plugin.yml
+++ b/prompt-paper/src/main/resources/paper-plugin.yml
@@ -31,7 +31,8 @@ permissions:
   promptpaper.reload:
     description: Allows using /commandprompter reload
   promptpaper.cancel:
-    description: Allows cancelling active prompts
+    description: Allows cancelling your own active prompt
+    default: true
   promptpaper.version:
     description: Allows using /commandprompter version
   promptpaper.use:

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
@@ -40,6 +40,9 @@ public class MockBukkitTest {
     @BeforeEach
     void setUp() {
         server = MockBukkit.mock();
+        server.getPluginManager().addPermission(
+                new org.bukkit.permissions.Permission("promptpaper.cancel", org.bukkit.permissions.PermissionDefault.TRUE)
+        );
 
         plugin = mock(CommandPrompter.class);
         when(plugin.getServer()).thenReturn(server);
@@ -130,6 +133,8 @@ public class MockBukkitTest {
 
         scheduler = new MockScheduler(plugin);
         when(plugin.getScheduler()).thenReturn(scheduler);
+
+        
     }
 
     @AfterEach

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/MockBukkitTest.java
@@ -40,9 +40,6 @@ public class MockBukkitTest {
     @BeforeEach
     void setUp() {
         server = MockBukkit.mock();
-        server.getPluginManager().addPermission(
-                new org.bukkit.permissions.Permission("promptpaper.cancel", org.bukkit.permissions.PermissionDefault.TRUE)
-        );
 
         plugin = mock(CommandPrompter.class);
         when(plugin.getServer()).thenReturn(server);
@@ -133,8 +130,6 @@ public class MockBukkitTest {
 
         scheduler = new MockScheduler(plugin);
         when(plugin.getScheduler()).thenReturn(scheduler);
-
-        
     }
 
     @AfterEach

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/PluginDescriptorTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/PluginDescriptorTest.java
@@ -1,0 +1,29 @@
+package dev.cyr1en.promptpaper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+class PluginDescriptorTest {
+
+    @Test
+    void cancelPermissionDefaultsToTrueInShippedDescriptor() throws IOException {
+        try (var descriptorStream = getClass().getResourceAsStream("/paper-plugin.yml")) {
+            assertNotNull(descriptorStream,
+                    "processed paper-plugin.yml should be on the test classpath");
+
+            var descriptor = YamlConfiguration.loadConfiguration(
+                    new InputStreamReader(descriptorStream, StandardCharsets.UTF_8));
+
+            assertEquals("Allows cancelling your own active prompt",
+                    descriptor.getString("permissions.promptpaper.cancel.description"));
+            assertTrue(descriptor.getBoolean("permissions.promptpaper.cancel.default"));
+        }
+    }
+}

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.beans.Transient;
+
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import dev.cyr1en.promptpaper.engine.PromptEngine;
 import dev.cyr1en.promptpaper.screen.ScreenManager;
@@ -69,5 +72,13 @@ class CancelCommandTest extends MockBukkitTest {
         var withPerm = mock(CommandSender.class);
         when(withPerm.hasPermission("promptpaper.cancel")).thenReturn(true);
         assertTrue(cmd.allowed(withPerm));
+    }
+
+    @Test
+    void nonOpPlayerCanCancelOwnSessionByDefault(){
+        PlayerMock player = createPlayer("Cassey");
+        player.setOp(false);
+        assertTrue(cmd.allowed(player),
+            "promptpaper.cancel should default to true so non-op players can cancel their own prompt");
     }
 }

--- a/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
+++ b/prompt-paper/src/test/java/dev/cyr1en/promptpaper/command/CancelCommandTest.java
@@ -8,13 +8,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.beans.Transient;
-
 import dev.cyr1en.promptpaper.MockBukkitTest;
 import dev.cyr1en.promptpaper.engine.PromptEngine;
 import dev.cyr1en.promptpaper.screen.ScreenManager;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
@@ -75,10 +75,19 @@ class CancelCommandTest extends MockBukkitTest {
     }
 
     @Test
-    void nonOpPlayerCanCancelOwnSessionByDefault(){
-        PlayerMock player = createPlayer("Cassey");
+    void nonOpPlayerCanCancelOwnSessionByDefault() {
+        server.getPluginManager().addPermission(
+                new Permission("promptpaper.cancel", PermissionDefault.TRUE));
+
+        PlayerMock player = createPlayer("Casey");
         player.setOp(false);
+
+        assertFalse(player.isOp());
         assertTrue(cmd.allowed(player),
-            "promptpaper.cancel should default to true so non-op players can cancel their own prompt");
+                "promptpaper.cancel should allow non-op players by default");
+
+        player.addAttachment(plugin, "promptpaper.cancel", false);
+        assertFalse(cmd.allowed(player),
+                "an explicit permission denial should still disable self-cancellation");
     }
 }


### PR DESCRIPTION
Fixes #103

## What changed

The visible Chat-prompt cancel control runs `/cmdp cancel`, which requires `promptpaper.cancel`. That permission had no declared default in `paper-plugin.yml`, so it silently fell back to op-only. Ordinary players could see the cancel button, but clicking it did nothing, while typing the configured cancel keyword worked.

`CancelCommand.executeCancel()` only cancels the sender's own active session; it cannot target another player's prompt. Self-cancellation therefore should not be operator-only.

## Fix

- `paper-plugin.yml`: declares `promptpaper.cancel` with `default: true` and clarifies that it permits cancelling only the sender's own prompt.
- `PluginDescriptorTest`: reads the processed, shipped `paper-plugin.yml` and asserts both the permission description and default, preventing the descriptor from drifting away from the intended behavior.
- `CancelCommandTest`: verifies that a non-op receives the permission by default and that an explicit permission denial still disables the command.
- Keeps permission setup local to the relevant test so unrelated MockBukkit tests are not affected.

## Security boundary

This changes only the default grant for the existing self-cancel command. The command still rejects non-player senders in its execution path and has no target-player argument. Server owners can explicitly deny `promptpaper.cancel` to disable self-cancellation for selected players or groups.

## Testing

- `./gradlew :prompt-paper:test --tests dev.cyr1en.promptpaper.PluginDescriptorTest --tests dev.cyr1en.promptpaper.command.CancelCommandTest`
- `./gradlew clean build`
- GitHub Java CI against the merged result with `development`

All checks pass.
